### PR TITLE
Feat: Implement a Mock Profile Creation Proxy

### DIFF
--- a/contracts/mocks/MockProfileCreationPProxy.sol
+++ b/contracts/mocks/MockProfileCreationPProxy.sol
@@ -1,0 +1,22 @@
+pragma solidity 0.8.10;
+
+import {ILensHub} from '../interfaces/ILensHub.sol';
+import {DataTypes} from '../libraries/DataTypes.sol';
+
+/**
+ * @title MockProfileCreationProxy
+ * @author Lens
+ *
+ * @dev This is a proxy to allow profiles to be created from any address.
+ */
+contract MockProfileCreationProxy {
+    ILensHub immutable LENS_HUB;
+
+    constructor(address hub) {
+        LENS_HUB = ILensHub(hub);
+    }
+
+    function proxyCreateProfile(DataTypes.CreateProfileData calldata vars) external {
+        LENS_HUB.createProfile(vars);
+    }
+}

--- a/test/other/mock-profile-creation-proxy.spec.ts
+++ b/test/other/mock-profile-creation-proxy.spec.ts
@@ -1,0 +1,79 @@
+import '@nomiclabs/hardhat-ethers';
+import { expect } from 'chai';
+import { ZERO_ADDRESS } from '../helpers/constants';
+import { ERRORS } from '../helpers/errors';
+import { MockProfileCreationProxy, MockProfileCreationProxy__factory } from '../../typechain-types';
+import {
+  approvalFollowModule,
+  deployer,
+  emptyCollectModule,
+  FIRST_PROFILE_ID,
+  followerOnlyReferenceModule,
+  governance,
+  governanceAddress,
+  lensHub,
+  makeSuiteCleanRoom,
+  mockFollowModule,
+  mockModuleData,
+  MOCK_FOLLOW_NFT_URI,
+  MOCK_PROFILE_HANDLE,
+  MOCK_PROFILE_URI,
+  MOCK_URI,
+  moduleGlobals,
+  OTHER_MOCK_URI,
+  timedFeeCollectModule,
+  treasuryAddress,
+  TREASURY_FEE_BPS,
+  user,
+  userAddress,
+  userTwo,
+  userTwoAddress,
+} from '../__setup.spec';
+import { BigNumber } from 'ethers';
+import { TokenDataStructOutput } from '../../typechain-types/LensHub';
+import { getTimestamp } from '../helpers/utils';
+
+makeSuiteCleanRoom('Mock Profile Creation Proxy', function () {
+  let mockProfileCreationProxy: MockProfileCreationProxy;
+  beforeEach(async function () {
+    mockProfileCreationProxy = await new MockProfileCreationProxy__factory(deployer).deploy(
+      lensHub.address
+    );
+    await expect(
+      lensHub.connect(governance).whitelistProfileCreator(mockProfileCreationProxy.address, true)
+    ).to.not.be.reverted;
+  });
+
+  it('User should be able to create a profile using the whitelisted proxy, received NFT should be valid', async function () {
+    let timestamp: any;
+    let owner: string;
+    let totalSupply: BigNumber;
+    let profileId: BigNumber;
+    let mintTimestamp: BigNumber;
+    let tokenData: TokenDataStructOutput;
+
+    await expect(
+      mockProfileCreationProxy.connect(user).proxyCreateProfile({
+        to: userAddress,
+        handle: MOCK_PROFILE_HANDLE,
+        imageURI: MOCK_PROFILE_URI,
+        followModule: ZERO_ADDRESS,
+        followModuleData: [],
+        followNFTURI: MOCK_FOLLOW_NFT_URI,
+      })
+    ).to.not.be.reverted;
+
+    timestamp = await getTimestamp();
+    owner = await lensHub.ownerOf(FIRST_PROFILE_ID);
+    totalSupply = await lensHub.totalSupply();
+    profileId = await lensHub.getProfileIdByHandle(MOCK_PROFILE_HANDLE);
+    mintTimestamp = await lensHub.mintTimestampOf(FIRST_PROFILE_ID);
+    tokenData = await lensHub.tokenDataOf(FIRST_PROFILE_ID);
+    expect(owner).to.eq(userAddress);
+    expect(totalSupply).to.eq(FIRST_PROFILE_ID);
+    expect(profileId).to.eq(FIRST_PROFILE_ID);
+    expect(mintTimestamp).to.eq(timestamp);
+    expect(tokenData.owner).to.eq(userAddress);
+    expect(tokenData.mintTimestamp).to.eq(timestamp);
+  });
+});


### PR DESCRIPTION
This PR introduces a mock contract called the `MockProfileCreationProxy`, it is an extremely simple contract that acts as a proxy to bypass the profile creation whitelist if needed. Users would call `proxyCreateProfile()` on this contract instead of calling `createProfile()` on the hub.

Note, however, that the `ProfileCreated()` event will emit the address of the `MockProfileCreationProxy` contract as the `creator`.