### PR TITLE
Governance Transfer Update

### DIFF
--- a/contracts/core/storage/LensHubStorage.sol
+++ b/contracts/core/storage/LensHubStorage.sol
@@ -68,5 +68,6 @@ contract LensHubStorage {
 
     uint256 internal _profileCounter;
     address internal _governance;
+    address internal _nextGovernance;
     address internal _emergencyAdmin;
 }

--- a/contracts/interfaces/ILensHub.sol
+++ b/contracts/interfaces/ILensHub.sol
@@ -28,11 +28,24 @@ interface ILensHub {
 
     /**
      * @notice Sets the privileged governance role. This function can only be called by the current governance
-     * address.
+     * address. Calling this function initiates governance transfer. To finalize, the `newGovernor` must
+     * call `acceptGovernance`. Throws if `newGovernance` is the zero address.
+     * To give up governance, call `renounceGovernance`.
      *
      * @param newGovernance The new governance address to set.
      */
     function setGovernance(address newGovernance) external;
+
+    /**
+     * @notice Sets the privileged governance role. This function can only be called by `_nextGovernance`, which
+     * is set by calling `setGovernance`.
+     */
+    function acceptGovernance() external;
+
+    /**
+     * @notice Renounces ownership by setting `_governance` to the zero address.
+     */
+    function renounceGovernance() external;
 
     /**
      * @notice Sets the emergency admin, which is a permissioned role able to set the protocol state. This function

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -12,6 +12,7 @@ library Errors {
     error NotHub();
     error TokenDoesNotExist();
     error NotGovernance();
+    error NotNextGovernance();
     error NotGovernanceOrEmergencyAdmin();
     error CallerNotWhitelistedModule();
     error CollectModuleNotWhitelisted();

--- a/test/other/events.spec.ts
+++ b/test/other/events.spec.ts
@@ -89,9 +89,11 @@ makeSuiteCleanRoom('Events', function () {
   context('Hub Governance', function () {
     it('Governance change should emit expected event', async function () {
       receipt = await waitForTx(lensHub.connect(governance).setGovernance(userAddress));
+
+      receipt = await waitForTx(lensHub.connect(user).acceptGovernance());
       expect(receipt.logs.length).to.eq(1);
       matchEvent(receipt, 'GovernanceSet', [
-        governanceAddress,
+        userAddress,
         governanceAddress,
         userAddress,
         await getTimestamp(),


### PR DESCRIPTION
Update governance to require a set and accept transaction using a "two-step ownable" pattern. Updating governance/ownership with two transactions is a lot safer since it ensures that the _next_ owner can submit transactions successfully. It effectively prevents accidental loss of ownership.