### PR TITLE
Add FollowOnlyCollect Module

### DIFF
--- a/contracts/core/modules/collect/FollowOnlyCollect.sol
+++ b/contracts/core/modules/collect/FollowOnlyCollect.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {LimitedFeeCollectModule, ProfilePublicationData} from './LimitedFeeCollectModule.sol';
+import {ICollectModule} from '../../../interfaces/ICollectModule.sol';
+import {ILensHub} from '../../../interfaces/ILensHub.sol';
+import {Errors} from '../../../libraries/Errors.sol';
+import {IERC721} from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+import "hardhat/console.sol";
+
+contract FollowOnlyCollect is LimitedFeeCollectModule {
+    constructor(address hub, address moduleGlobals) LimitedFeeCollectModule(hub, moduleGlobals) {}
+
+    /**
+     * @param data The arbitrary data parameter, decoded into:
+     *    uint256 profile: Additional profile collector has to follow.
+     *    uint256 maxID: Maximum ID of follower id allowed for collector w.r.t additional profile. 
+     *
+     * @dev Processes a collect by:
+     *  1. Ensuring the collector is a follower
+     *  2. 
+     *  2. Ensuring the collect does not pass the collect limit
+     *  3. Charging a fee
+     */
+    function processCollect(
+        uint256 referrerProfileId,
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) external override onlyHub {
+        (,, uint256 profile, uint256 maxID) = abi.decode(
+            data,
+            (address, uint256, uint256, uint256)
+        );
+        _checkFollowValidity(profileId, collector);
+        _checkFollowValidityLimit(profile, collector, maxID);
+
+        if (
+            _dataByPublicationByProfile[profileId][pubId].currentCollects >=
+            _dataByPublicationByProfile[profileId][pubId].collectLimit
+        ) {
+            revert Errors.MintLimitExceeded();
+        } else {
+            _dataByPublicationByProfile[profileId][pubId].currentCollects++;
+            if (referrerProfileId == profileId) {
+                _processCollect(collector, profileId, pubId, data);
+            } else {
+                _processCollectWithReferral(referrerProfileId, collector, profileId, pubId, data);
+            }
+        }
+    }
+
+    function _checkFollowValidityLimit(
+        uint256 profileId,
+        address collector,
+        uint256 maxID
+    ) private {
+        address followNFT = ILensHub(HUB).getFollowNFT(profileId);
+        if (followNFT == address(0)) revert Errors.FollowInvalid();
+        uint256 followCount = IERC721(followNFT).balanceOf(collector);
+        if (followCount == 0) revert Errors.FollowInvalid();
+        if (followCount > maxID) revert Errors.NotInFollowerLimit();
+    }
+}

--- a/contracts/core/modules/collect/LimitedFeeCollectModule.sol
+++ b/contracts/core/modules/collect/LimitedFeeCollectModule.sol
@@ -100,7 +100,7 @@ contract LimitedFeeCollectModule is ICollectModule, FeeModuleBase, FollowValidat
         uint256 profileId,
         uint256 pubId,
         bytes calldata data
-    ) external override onlyHub {
+    ) virtual external override onlyHub {
         _checkFollowValidity(profileId, collector);
 
         if (

--- a/contracts/libraries/Errors.sol
+++ b/contracts/libraries/Errors.sol
@@ -28,7 +28,8 @@ library Errors {
     error CallerNotCollectNFT();
     error BlockNumberInvalid();
     error ArrayMismatch();
-
+    error NotInFollowerLimit();
+    
     // Module Errors
     error InitParamsInvalid();
     error ZeroCurrency();

--- a/tasks/full-deploy.ts
+++ b/tasks/full-deploy.ts
@@ -12,6 +12,7 @@ import {
   FeeFollowModule__factory,
   FollowerOnlyReferenceModule__factory,
   FollowNFT__factory,
+  FollowOnlyCollect__factory,
   InteractionLogic__factory,
   LimitedFeeCollectModule__factory,
   LimitedTimedFeeCollectModule__factory,
@@ -131,6 +132,12 @@ task('full-deploy', 'deploys the entire Lens Protocol').setAction(async ({}, hre
       nonce: deployerNonce++,
     })
   );
+  console.log('\n\t-- Deploying followOnlyCollectModule --');
+  const followOnlyCollectModule = await deployContract(
+    new FollowOnlyCollect__factory(deployer).deploy(lensHub.address, moduleGlobals.address, {
+      nonce: deployerNonce++,
+    })
+  );
   console.log('\n\t-- Deploying timedFeeCollectModule --');
   const timedFeeCollectModule = await deployContract(
     new TimedFeeCollectModule__factory(deployer).deploy(lensHub.address, moduleGlobals.address, {
@@ -187,6 +194,11 @@ task('full-deploy', 'deploys the entire Lens Protocol').setAction(async ({}, hre
     })
   );
   await waitForTx(
+    lensHub.whitelistCollectModule(followOnlyCollectModule.address, true, {
+      nonce: governanceNonce++,
+    })
+  );
+  await waitForTx(
     lensHub.whitelistCollectModule(timedFeeCollectModule.address, true, { nonce: governanceNonce++ })
   );
   await waitForTx(
@@ -238,6 +250,7 @@ task('full-deploy', 'deploys the entire Lens Protocol').setAction(async ({}, hre
     'module globals': moduleGlobals.address,
     'fee collect module': feeCollectModule.address,
     'limited fee collect module': limitedFeeCollectModule.address,
+    'follow only collect module': followOnlyCollectModule.address,
     'timed fee collect module': timedFeeCollectModule.address,
     'limited timed fee collect module': limitedTimedFeeCollectModule.address,
     'revert collect module': revertCollectModule.address,

--- a/test/__setup.spec.ts
+++ b/test/__setup.spec.ts
@@ -22,6 +22,8 @@ import {
   FollowerOnlyReferenceModule,
   FollowerOnlyReferenceModule__factory,
   FollowNFT__factory,
+  FollowOnlyCollect,
+  FollowOnlyCollect__factory,
   Helper,
   Helper__factory,
   InteractionLogic__factory,
@@ -62,7 +64,9 @@ export const REFERRAL_FEE_BPS = 250;
 export const LENS_HUB_NFT_NAME = 'Lens Profiles';
 export const LENS_HUB_NFT_SYMBOL = 'LENS';
 export const MOCK_PROFILE_HANDLE = 'plant1ghost.eth';
+export const MOCK_PROFILE_HANDLE_TWO = 'plant1devil.eth';
 export const FIRST_PROFILE_ID = 1;
+export const SECOND_PROFILE_ID = 2;
 export const MOCK_URI =
   'https://ipfs.fleek.co/ipfs/plantghostplantghostplantghostplantghostplantghostplantghos';
 export const OTHER_MOCK_URI =
@@ -76,10 +80,12 @@ export let accounts: Signer[];
 export let deployer: Signer;
 export let user: Signer;
 export let userTwo: Signer;
+export let userThree: Signer;
 export let governance: Signer;
 export let deployerAddress: string;
 export let userAddress: string;
 export let userTwoAddress: string;
+export let userThreeAddress: string;
 export let governanceAddress: string;
 export let followNFTImplAddress: string;
 export let collectNFTImplAddress: string;
@@ -104,6 +110,7 @@ export let emptyCollectModule: EmptyCollectModule;
 export let revertCollectModule: RevertCollectModule;
 export let limitedFeeCollectModule: LimitedFeeCollectModule;
 export let limitedTimedFeeCollectModule: LimitedTimedFeeCollectModule;
+export let followOnlyCollect: FollowOnlyCollect;
 
 // Follow
 export let approvalFollowModule: ApprovalFollowModule;
@@ -134,9 +141,11 @@ before(async function () {
   user = accounts[1];
   userTwo = accounts[2];
   governance = accounts[3];
+  userThree = accounts[4];
   deployerAddress = await deployer.getAddress();
   userAddress = await user.getAddress();
   userTwoAddress = await userTwo.getAddress();
+  userThreeAddress = await userThree.getAddress();
   governanceAddress = await governance.getAddress();
   treasuryAddress = await accounts[4].getAddress();
   mockModuleData = abiCoder.encode(['uint256'], [1]);
@@ -204,6 +213,10 @@ before(async function () {
     moduleGlobals.address
   );
   limitedTimedFeeCollectModule = await new LimitedTimedFeeCollectModule__factory(deployer).deploy(
+    lensHub.address,
+    moduleGlobals.address
+  );
+  followOnlyCollect = await new FollowOnlyCollect__factory(deployer).deploy(
     lensHub.address,
     moduleGlobals.address
   );

--- a/test/helpers/errors.ts
+++ b/test/helpers/errors.ts
@@ -28,6 +28,7 @@ export const ERRORS = {
   COLLECT_NOT_ALLOWED: 'CollectNotAllowed()',
   MINT_LIMIT_EXCEEDED: 'MintLimitExceeded()',
   FOLLOW_INVALID: 'FollowInvalid()',
+  NOT_IN_FOLLOWER_LIMIT: 'NotInFollowerLimit()',
   MODULE_DATA_MISMATCH: 'ModuleDataMismatch()',
   FOLLOW_NOT_APPROVED: 'FollowNotApproved()',
   ARRAY_MISMATCH: 'ArrayMismatch()',

--- a/test/modules/collect/follow-only-collect.spec.ts
+++ b/test/modules/collect/follow-only-collect.spec.ts
@@ -1,0 +1,730 @@
+import { BigNumber } from '@ethersproject/contracts/node_modules/@ethersproject/bignumber';
+import { parseEther } from '@ethersproject/units';
+import '@nomiclabs/hardhat-ethers';
+import { expect } from 'chai';
+import { MAX_UINT256, ZERO_ADDRESS } from '../../helpers/constants';
+import { ERRORS } from '../../helpers/errors';
+import { getTimestamp, matchEvent, waitForTx } from '../../helpers/utils';
+import {
+  abiCoder,
+  BPS_MAX,
+  currency,
+  FIRST_PROFILE_ID,
+  SECOND_PROFILE_ID,
+  governance,
+  lensHub,
+  followOnlyCollect,
+  makeSuiteCleanRoom,
+  MOCK_FOLLOW_NFT_URI,
+  MOCK_PROFILE_HANDLE,
+  MOCK_PROFILE_HANDLE_TWO,
+  MOCK_PROFILE_URI,
+  MOCK_URI,
+  moduleGlobals,
+  REFERRAL_FEE_BPS,
+  treasuryAddress,
+  TREASURY_FEE_BPS,
+  userAddress,
+  userTwo,
+  userTwoAddress,
+  userThreeAddress,
+} from '../../__setup.spec';
+
+makeSuiteCleanRoom('Follow Only Collect Module', function () {
+  const DEFAULT_COLLECT_PRICE = parseEther('10');
+  const DEFAULT_COLLECT_LIMIT = 3;
+
+  beforeEach(async function () {
+    await expect(
+      lensHub.createProfile({
+        to: userAddress,
+        handle: MOCK_PROFILE_HANDLE,
+        imageURI: MOCK_PROFILE_URI,
+        followModule: ZERO_ADDRESS,
+        followModuleData: [],
+        followNFTURI: MOCK_FOLLOW_NFT_URI,
+      })
+    ).to.not.be.reverted;
+    await expect(
+      lensHub.createProfile({
+        to: userThreeAddress,
+        handle: MOCK_PROFILE_HANDLE_TWO,
+        imageURI: MOCK_PROFILE_URI,
+        followModule: ZERO_ADDRESS,
+        followModuleData: [],
+        followNFTURI: MOCK_FOLLOW_NFT_URI,
+      })
+    ).to.not.be.reverted;
+    await expect(
+      lensHub.connect(governance).whitelistCollectModule(followOnlyCollect.address, true)
+    ).to.not.be.reverted;
+    await expect(
+      moduleGlobals.connect(governance).whitelistCurrency(currency.address, true)
+    ).to.not.be.reverted;
+  });
+
+  context('Negatives', function () {
+    context('Publication Creation', function () {
+      it('user should fail to post with limited fee collect module using zero collect limit', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [0, DEFAULT_COLLECT_PRICE, currency.address, userAddress, REFERRAL_FEE_BPS]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: followOnlyCollect.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with limited fee collect module using unwhitelisted currency', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            DEFAULT_COLLECT_PRICE,
+            userTwoAddress,
+            userAddress,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: followOnlyCollect.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with limited fee collect module using zero recipient', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            ZERO_ADDRESS,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: followOnlyCollect.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with limited fee collect module using referral fee greater than max BPS', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [DEFAULT_COLLECT_LIMIT, DEFAULT_COLLECT_PRICE, currency.address, userAddress, 10001]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: followOnlyCollect.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with limited fee collect module using amount lower than max BPS', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [DEFAULT_COLLECT_LIMIT, 9999, currency.address, userAddress, REFERRAL_FEE_BPS]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: followOnlyCollect.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+    });
+
+    context('Collecting', function () {
+      beforeEach(async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: followOnlyCollect.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+      });
+
+      it('UserTwo should fail to collect without following', async function () {
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.FOLLOW_INVALID);
+      });
+
+      it('UserTwo should fail to collect without following additional profile', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.FOLLOW_INVALID);
+      });
+
+      it('UserTwo should fail to collect with follower Id second profile on additional profile is greater than maxID', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 0]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.NOT_IN_FOLLOWER_LIMIT);
+      });
+
+      it('UserTwo should fail to collect passing a different expected price in data', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE.div(2), SECOND_PROFILE_ID, 10]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should fail to collect passing a different expected currency in data', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256', 'uint256'],
+          [userAddress, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should fail to collect without first approving module with currency', async function () {
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.ERC20_TRANSFER_EXCEEDS_ALLOWANCE);
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror without following the original profile', async function () {
+        const newProfileId = SECOND_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: newProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+        );
+        await expect(lensHub.connect(userTwo).collect(newProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.FOLLOW_INVALID
+        );
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror passing a different expected price in data', async function () {
+        const newProfileId = SECOND_PROFILE_ID + 1;
+
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: newProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE.div(2), SECOND_PROFILE_ID, 10]
+        );
+        await expect(lensHub.connect(userTwo).collect(newProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.MODULE_DATA_MISMATCH
+        );
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror passing a different expected currency in data', async function () {
+        const newProfileId = SECOND_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: newProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256', 'uint256', 'uint256'],
+          [userAddress, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+        );
+        await expect(lensHub.connect(userTwo).collect(newProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.MODULE_DATA_MISMATCH
+        );
+      });
+    });
+  });
+
+  context('Scenarios', function () {
+    it('User should post with limited fee collect module as the collect module and data, correct events should be emitted', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      const tx = lensHub.post({
+        profileId: FIRST_PROFILE_ID,
+        contentURI: MOCK_URI,
+        collectModule: followOnlyCollect.address,
+        collectModuleData: collectModuleData,
+        referenceModule: ZERO_ADDRESS,
+        referenceModuleData: [],
+      });
+
+      const receipt = await waitForTx(tx);
+
+      expect(receipt.logs.length).to.eq(1);
+      matchEvent(receipt, 'PostCreated', [
+        FIRST_PROFILE_ID,
+        1,
+        MOCK_URI,
+        followOnlyCollect.address,
+        collectModuleData,
+        ZERO_ADDRESS,
+        [],
+        await getTimestamp(),
+      ]);
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, fetched publication data should be accurate', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: followOnlyCollect.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      const fetchedData = await followOnlyCollect.getPublicationData(FIRST_PROFILE_ID, 1);
+      expect(fetchedData.collectLimit).to.eq(DEFAULT_COLLECT_LIMIT);
+      expect(fetchedData.amount).to.eq(DEFAULT_COLLECT_PRICE);
+      expect(fetchedData.recipient).to.eq(userAddress);
+      expect(fetchedData.currency).to.eq(currency.address);
+      expect(fetchedData.referralFee).to.eq(REFERRAL_FEE_BPS);
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, user two follows, then collects and pays fee, fee distribution is valid', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: followOnlyCollect.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(followOnlyCollect.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+
+      const data = abiCoder.encode(
+        ['address', 'uint256', 'uint256', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+      );
+      expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, user two follows, then collects twice, fee distribution is valid', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: followOnlyCollect.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(followOnlyCollect.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256', 'uint256', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(BigNumber.from(DEFAULT_COLLECT_PRICE).mul(2))
+      );
+      expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount.mul(2));
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount.mul(2));
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, user two mirrors, follows, then collects from their mirror and pays fee, fee distribution is valid', async function () {
+      const newProfileId = SECOND_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: followOnlyCollect.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: newProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(followOnlyCollect.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256', 'uint256', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+      );
+      await expect(lensHub.connect(userTwo).collect(newProfileId, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedReferralAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .sub(expectedTreasuryAmount)
+        .mul(REFERRAL_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedReferrerAmount = BigNumber.from(MAX_UINT256)
+        .sub(DEFAULT_COLLECT_PRICE)
+        .add(expectedReferralAmount);
+      const expectedRecipientAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .sub(expectedTreasuryAmount)
+        .sub(expectedReferralAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(expectedReferrerAmount);
+      expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, with no referral fee, user two mirrors, follows, then collects from their mirror and pays fee, fee distribution is valid', async function () {
+      const newProfileId = SECOND_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [DEFAULT_COLLECT_LIMIT, DEFAULT_COLLECT_PRICE, currency.address, userAddress, 0]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: followOnlyCollect.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: newProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(followOnlyCollect.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256', 'uint256', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+      );
+      await expect(lensHub.connect(userTwo).collect(newProfileId, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+      );
+      expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, user two mirrors, follows, then collects once from the original, twice from the mirror, and fails to collect a third time from either the mirror or the original', async function () {
+      const newProfileId = SECOND_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: followOnlyCollect.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: newProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(followOnlyCollect.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([SECOND_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256', 'uint256', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE, SECOND_PROFILE_ID, 10]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).collect(newProfileId, 1, data)).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).collect(newProfileId, 1, data)).to.not.be.reverted;
+
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.be.revertedWith(
+        ERRORS.MINT_LIMIT_EXCEEDED
+      );
+      await expect(lensHub.connect(userTwo).collect(newProfileId, 1, data)).to.be.revertedWith(
+        ERRORS.MINT_LIMIT_EXCEEDED
+      );
+    });
+  });
+});


### PR DESCRIPTION
FollowOnlyCollect as part of Bounty.

FollowOnlyCollect (1 ETH) - Extend the LimitedFeeCollectModule to take 2 added inputs “profile” and “maxID”, validate the wallet trying to collect holds the FollowNFT of “profile” and has an ID less than or equal to “maxID” before processing collect.

Pull request includes
1. FollowOnlyCollect
2. Tests for follow only collect.