### PR TITLE
Add BCTRetireCollectModule (a.k.a. ReFiCollectModule)

### DIFF
--- a/contracts/core/modules/collect/BCTRetireCollectModule.sol
+++ b/contracts/core/modules/collect/BCTRetireCollectModule.sol
@@ -1,0 +1,219 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import "@openzeppelin/contracts/utils/Strings.sol";
+
+import {ICollectModule} from '../../../interfaces/ICollectModule.sol';
+import {Errors} from '../../../libraries/Errors.sol';
+import {FeeModuleBase} from '../FeeModuleBase.sol';
+import {ModuleBase} from '../ModuleBase.sol';
+import {FollowValidationModuleBase} from '../FollowValidationModuleBase.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC721} from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+import {IKlimaRetirementAggregator} from '../../../interfaces/IKlimaRetirementAggregator.sol';
+
+/**
+ * @notice A struct containing the necessary data to execute collect actions on a publication.
+ *
+ * @param amount The collecting cost associated with this publication.
+ * @param recipient The recipient address associated with this publication.
+ * @param currency The currency associated with this publication.
+ * @param referralFee The referral fee associated with this publication.
+ */
+struct ProfilePublicationData {
+    uint256 amount;
+    address recipient;
+    address currency;
+    uint16 referralFee;
+}
+
+/**
+ * @title BCTRetireCollectModule
+ * @author Lens Protocol
+ *
+ * @notice This is a Lens CollectModule implementation, inheriting from the ICollectModule interface and
+ * the FeeCollectModuleBase abstract contract.
+ *
+ * This module works by allowing unlimited collects for a publication at a given price.
+ */
+contract BCTRetireCollectModule is ICollectModule, FeeModuleBase, FollowValidationModuleBase {
+    using SafeERC20 for IERC20;
+
+    mapping(uint256 => mapping(uint256 => ProfilePublicationData))
+        internal _dataByPublicationByProfile;
+
+    address public immutable BASE_CARBON_TONNE;
+    address public immutable RETIREMENT_HELPER;
+
+    constructor(address hub, address moduleGlobals, address baseCarbonTonne, address retirementHelper) FeeModuleBase(moduleGlobals) ModuleBase(hub) {
+        BASE_CARBON_TONNE = baseCarbonTonne;
+        RETIREMENT_HELPER = retirementHelper;
+    }
+
+    /**
+     * @notice This collect module supports the same functionality as FeeCollectModule, but swaps the fee collected to BCT and burns it. Thus, we need to decode data and execute a SushiSwap trade.
+     *
+     * @param profileId The token ID of the profile of the publisher, passed by the hub.
+     * @param pubId The publication ID of the newly created publication, passed by the hub.
+     * @param data The arbitrary data parameter, decoded into:
+     *      uint256 amount: The currency total amount to levy.
+     *      address currency: The currency address, must be internally whitelisted.
+     *      address recipient: The custom recipient address to direct earnings to.
+     *      uint16 referralFee: The referral fee to set.
+     *
+     * @return An abi encoded bytes parameter, which is the same as the passed data parameter.
+     */
+    function initializePublicationCollectModule(
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) external override onlyHub returns (bytes memory) {
+        (uint256 amount, address currency, address recipient, uint16 referralFee) = abi.decode(
+            data,
+            (uint256, address, address, uint16)
+        );
+        if (
+            !_currencyWhitelisted(currency) ||
+            recipient == address(0) ||
+            referralFee > BPS_MAX ||
+            amount < BPS_MAX
+        ) revert Errors.InitParamsInvalid();
+
+        _dataByPublicationByProfile[profileId][pubId].referralFee = referralFee;
+        _dataByPublicationByProfile[profileId][pubId].recipient = recipient;
+        _dataByPublicationByProfile[profileId][pubId].currency = currency;
+        _dataByPublicationByProfile[profileId][pubId].amount = amount;
+
+        return data;
+    }
+
+    /**
+     * @dev Processes a collect by:
+     *  1. Ensuring the collector is a follower
+     *  2. Charging a fee
+     *  3. Swap the fee amount to BCT and retire it
+     */
+    function processCollect(
+        uint256 referrerProfileId,
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) external virtual override onlyHub {
+        _checkFollowValidity(profileId, collector);
+        if (referrerProfileId == profileId) {
+            _processCollect(collector, profileId, pubId, data);
+        } else {
+            _processCollectWithReferral(referrerProfileId, collector, profileId, pubId, data);
+        }
+    }
+
+    /**
+     * @notice Returns the publication data for a given publication, or an empty struct if that publication was not
+     * initialized with this module.
+     *
+     * @param profileId The token ID of the profile mapped to the publication to query.
+     * @param pubId The publication ID of the publication to query.
+     *
+     * @return The ProfilePublicationData struct mapped to that publication.
+     */
+    function getPublicationData(uint256 profileId, uint256 pubId)
+        external
+        view
+        returns (ProfilePublicationData memory)
+    {
+        return _dataByPublicationByProfile[profileId][pubId];
+    }
+
+    function _retireBCT(
+        address collector,
+        address beneficiary,
+        uint256 pubId,
+        address currency,
+        uint256 amount
+    ) internal {
+        // Transfer amount to be retired to the retirement helper contract
+        IERC20(currency).safeTransferFrom(collector, RETIREMENT_HELPER, amount);
+
+        // Swap adjusted fee to BCT and retire
+        string memory retirementMessage = string(abi.encodePacked(
+            "Lens Protocol Collection Fee for Publication: ",
+            Strings.toString(pubId)
+        ));
+        IKlimaRetirementAggregator(RETIREMENT_HELPER).retireCarbonFrom(
+            beneficiary,
+            currency,
+            BASE_CARBON_TONNE,
+            amount,
+            false,
+            beneficiary,
+            "Lens Protocol Profile",
+            retirementMessage
+        );
+    }
+
+    function _processCollect(
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) internal {
+        uint256 amount = _dataByPublicationByProfile[profileId][pubId].amount;
+        address currency = _dataByPublicationByProfile[profileId][pubId].currency;
+        _validateDataIsExpected(data, currency, amount);
+
+        (address treasury, uint16 treasuryFee) = _treasuryData();
+        address recipient = _dataByPublicationByProfile[profileId][pubId].recipient;
+        uint256 treasuryAmount = (amount * treasuryFee) / BPS_MAX;
+        uint256 adjustedAmount = amount - treasuryAmount;
+
+        _retireBCT(collector, recipient, pubId, currency, adjustedAmount); // beneficiary is recipient since they paid the fee
+
+        // Transfer treasury amount as usual
+        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+    }
+
+    function _processCollectWithReferral(
+        uint256 referrerProfileId,
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) internal {
+        uint256 amount = _dataByPublicationByProfile[profileId][pubId].amount;
+        address currency = _dataByPublicationByProfile[profileId][pubId].currency;
+        _validateDataIsExpected(data, currency, amount);
+
+        uint256 referralFee = _dataByPublicationByProfile[profileId][pubId].referralFee;
+        address treasury;
+        uint256 treasuryAmount;
+
+        // Avoids stack too deep
+        {
+            uint16 treasuryFee;
+            (treasury, treasuryFee) = _treasuryData();
+            treasuryAmount = (amount * treasuryFee) / BPS_MAX;
+        }
+
+        uint256 adjustedAmount = amount - treasuryAmount;
+
+        if (referralFee != 0) {
+            // The reason we levy the referral fee on the adjusted amount is so that referral fees
+            // don't bypass the treasury fee, in essence referrals pay their fair share to the treasury.
+            uint256 referralAmount = (adjustedAmount * referralFee) / BPS_MAX;
+            adjustedAmount = adjustedAmount - referralAmount;
+
+            address referralRecipient = IERC721(HUB).ownerOf(referrerProfileId);
+
+            IERC20(currency).safeTransferFrom(collector, referralRecipient, referralAmount);
+        }
+        address recipient = _dataByPublicationByProfile[profileId][pubId].recipient;
+
+        _retireBCT(collector, recipient, pubId, currency, adjustedAmount); // beneficiary is recipient since they paid the fee
+
+        // Transfer treasury amount as usual
+        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+    }
+}

--- a/contracts/interfaces/IERC20Burnable.sol
+++ b/contracts/interfaces/IERC20Burnable.sol
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.5.0) (token/ERC20/IERC20.sol)
+
+pragma solidity 0.8.10;
+
+/**
+ * @dev Extension of the ERC20 standard to support burning.
+ */
+interface IERC20Burnable {
+    /**
+     * @dev Returns the amount of tokens in existence.
+     */
+    function totalSupply() external view returns (uint256);
+
+    /**
+     * @dev Returns the amount of tokens owned by `account`.
+     */
+    function balanceOf(address account) external view returns (uint256);
+
+    /**
+     * @dev Moves `amount` tokens from the caller's account to `to`.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transfer(address to, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Returns the remaining number of tokens that `spender` will be
+     * allowed to spend on behalf of `owner` through {transferFrom}. This is
+     * zero by default.
+     *
+     * This value changes when {approve} or {transferFrom} are called.
+     */
+    function allowance(address owner, address spender) external view returns (uint256);
+
+    /**
+     * @dev Sets `amount` as the allowance of `spender` over the caller's tokens.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * IMPORTANT: Beware that changing an allowance with this method brings the risk
+     * that someone may use both the old and the new allowance by unfortunate
+     * transaction ordering. One possible solution to mitigate this race
+     * condition is to first reduce the spender's allowance to 0 and set the
+     * desired value afterwards:
+     * https://github.com/ethereum/EIPs/issues/20#issuecomment-263524729
+     *
+     * Emits an {Approval} event.
+     */
+    function approve(address spender, uint256 amount) external returns (bool);
+
+    /**
+     * @dev Moves `amount` tokens from `from` to `to` using the
+     * allowance mechanism. `amount` is then deducted from the caller's
+     * allowance.
+     *
+     * Returns a boolean value indicating whether the operation succeeded.
+     *
+     * Emits a {Transfer} event.
+     */
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) external returns (bool);
+
+        /**
+     * @dev Destroys `amount` tokens from the caller.
+     *
+     * See {ERC20-_burn}.
+     */
+    function burn(uint256 amount) external;
+
+    /**
+     * @dev Destroys `amount` tokens from `account`, deducting from the caller's
+     * allowance.
+     *
+     * See {ERC20-_burn} and {ERC20-allowance}.
+     *
+     * Requirements:
+     *
+     * - the caller must have allowance for ``accounts``'s tokens of at least
+     * `amount`.
+     */
+    function burnFrom(address account, uint256 amount) external;
+
+    /**
+     * @dev Emitted when `value` tokens are moved from one account (`from`) to
+     * another (`to`).
+     *
+     * Note that `value` may be zero.
+     */
+    event Transfer(address indexed from, address indexed to, uint256 value);
+
+    /**
+     * @dev Emitted when the allowance of a `spender` for an `owner` is set by
+     * a call to {approve}. `value` is the new allowance.
+     */
+    event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/contracts/interfaces/IKlimaRetirementAggregator.sol
+++ b/contracts/interfaces/IKlimaRetirementAggregator.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+/**
+ * @title IKlimaRetirementAggregator
+ * @author KlimaDAO
+ *
+ * @notice This is the interface for the KlimaDAO carbon offset retirement aggregator contract.
+ */
+interface IKlimaRetirementAggregator {
+    /**
+     * @notice Retires the specified carbon offset token with the provided parameters.
+     *
+     * @param _sourceToken The token ID of the currency being provided.
+     * @param _poolToken The token ID of the carbon offset pool to retire from (e.g. BCT, MCO2).
+     * @param _amount Amount of carbon offsets to retire, or amount of currency provided - behavior controlled by _amountInCarbon.
+     * @param _amountInCarbon Indicates whether the _amount value represents the amout of the currency provided or the amount of carbon the user wants to retire.
+     * @param _beneficiaryAddress Address on whose behalf the offsets are being retired.
+     * @param _beneficiaryString Describes the beneficiary of the retirement.
+     * @param _retirementMessage Describes the reason or context for the retirement.
+     */
+    function retireCarbon(
+        address _sourceToken,
+        address _poolToken,
+        uint256 _amount,
+        bool _amountInCarbon,
+        address _beneficiaryAddress,
+        string memory _beneficiaryString,
+        string memory _retirementMessage
+    ) external;
+
+    /**
+     * @notice Retires the specified carbon offset token with the provided parameters, but assumes the source token are already transferred to this contract.
+     *
+     * @param _recipient The address which should receive back any _sourceToken dust if _amountInCarbon is true.
+     * @param _sourceToken The token ID of the currency being provided.
+     * @param _poolToken The token ID of the carbon offset pool to retire from (e.g. BCT, MCO2).
+     * @param _amount Amount of carbon offsets to retire, or amount of currency provided - behavior controlled by _amountInCarbon.
+     * @param _amountInCarbon Indicates whether the _amount value represents the amout of the currency provided or the amount of carbon the user wants to retire.
+     * @param _beneficiaryAddress Address on whose behalf the offsets are being retired.
+     * @param _beneficiaryString Describes the beneficiary of the retirement.
+     * @param _retirementMessage Describes the reason or context for the retirement.
+     */
+    function retireCarbonFrom(
+        address _recipient,
+        address _sourceToken,
+        address _poolToken,
+        uint256 _amount,
+        bool _amountInCarbon,
+        address _beneficiaryAddress,
+        string memory _beneficiaryString,
+        string memory _retirementMessage
+    ) external;
+}

--- a/contracts/mocks/Currency.sol
+++ b/contracts/mocks/Currency.sol
@@ -8,4 +8,8 @@ contract Currency is ERC20('Currency', 'CRNC') {
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
     }
+
+    function burnFrom(address from, uint256 amount) external {
+        _burn(from, amount);
+    }
 }

--- a/contracts/mocks/MockKlimaRetirementAggregator.sol
+++ b/contracts/mocks/MockKlimaRetirementAggregator.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {IERC20Burnable} from '../interfaces/IERC20Burnable.sol';
+
+contract MockKlimaRetirementAggregator {
+
+    function retireCarbonFrom (
+        address _recipient,
+        address _sourceToken,
+        address _poolToken,
+        uint256 _amount,
+        bool _amountInCarbon,
+        address _beneficiaryAddress,
+        string memory _beneficiaryString,
+        string memory _retirementMessage
+    ) external {
+        // The actual contract would swap for and properly retire BCT
+        IERC20Burnable(_sourceToken).burnFrom(address(this), _amount);
+    }
+}

--- a/test/__setup.spec.ts
+++ b/test/__setup.spec.ts
@@ -8,6 +8,8 @@ import { ethers } from 'hardhat';
 import {
   ApprovalFollowModule,
   ApprovalFollowModule__factory,
+  BCTRetireCollectModule,
+  BCTRetireCollectModule__factory,
   CollectNFT__factory,
   Currency,
   Currency__factory,
@@ -35,6 +37,8 @@ import {
   MockFollowModule__factory,
   MockReferenceModule,
   MockReferenceModule__factory,
+  MockKlimaRetirementAggregator,
+  MockKlimaRetirementAggregator__factory,
   ModuleGlobals,
   ModuleGlobals__factory,
   ProfileTokenURILogic__factory,
@@ -116,6 +120,7 @@ export let freeCollectModule: FreeCollectModule;
 export let revertCollectModule: RevertCollectModule;
 export let limitedFeeCollectModule: LimitedFeeCollectModule;
 export let limitedTimedFeeCollectModule: LimitedTimedFeeCollectModule;
+export let bctRetireCollectModule: BCTRetireCollectModule;
 
 // Follow
 export let approvalFollowModule: ApprovalFollowModule;
@@ -127,6 +132,10 @@ export let mockFollowModule: MockFollowModule;
 // Reference
 export let followerOnlyReferenceModule: FollowerOnlyReferenceModule;
 export let mockReferenceModule: MockReferenceModule;
+
+// Helpers
+export let carbonToken: Currency;
+export let mockKlimaRetirementAggregator: MockKlimaRetirementAggregator;
 
 export function makeSuiteCleanRoom(name: string, tests: () => void) {
   describe(name, () => {
@@ -232,6 +241,16 @@ before(async function () {
     moduleGlobals.address
   );
 
+  // Carbon Offset Retirement Collect modules
+  carbonToken = await new Currency__factory(deployer).deploy();
+  mockKlimaRetirementAggregator = await new MockKlimaRetirementAggregator__factory(deployer).deploy();
+  bctRetireCollectModule = await new BCTRetireCollectModule__factory(deployer).deploy(
+    lensHub.address,
+    moduleGlobals.address,
+    carbonToken.address,
+    mockKlimaRetirementAggregator.address
+    );
+
   feeFollowModule = await new FeeFollowModule__factory(deployer).deploy(
     lensHub.address,
     moduleGlobals.address
@@ -265,6 +284,7 @@ before(async function () {
   expect(timedFeeCollectModule).to.not.be.undefined;
   expect(mockFollowModule).to.not.be.undefined;
   expect(mockReferenceModule).to.not.be.undefined;
+  expect(mockKlimaRetirementAggregator).to.not.be.undefined;
 
   // Event library deployment is only needed for testing and is not reproduced in the live environment
   eventsLib = await new Events__factory(deployer).deploy();

--- a/test/modules/collect/bct-retire-collect-module.spec.ts
+++ b/test/modules/collect/bct-retire-collect-module.spec.ts
@@ -1,0 +1,537 @@
+import { BigNumber } from '@ethersproject/contracts/node_modules/@ethersproject/bignumber';
+import { parseEther } from '@ethersproject/units';
+import '@nomiclabs/hardhat-ethers';
+import { expect } from 'chai';
+import { MAX_UINT256, ZERO_ADDRESS } from '../../helpers/constants';
+import { ERRORS } from '../../helpers/errors';
+import { getTimestamp, matchEvent, waitForTx } from '../../helpers/utils';
+import {
+  abiCoder,
+  BPS_MAX,
+  currency,
+  bctRetireCollectModule,
+  FIRST_PROFILE_ID,
+  governance,
+  lensHub,
+  makeSuiteCleanRoom,
+  MOCK_FOLLOW_NFT_URI,
+  MOCK_PROFILE_HANDLE,
+  MOCK_PROFILE_URI,
+  MOCK_URI,
+  moduleGlobals,
+  REFERRAL_FEE_BPS,
+  treasuryAddress,
+  TREASURY_FEE_BPS,
+  userAddress,
+  userTwo,
+  userTwoAddress,
+} from '../../__setup.spec';
+
+makeSuiteCleanRoom('BCT Retire Collect Module', function () {
+  const DEFAULT_COLLECT_PRICE = parseEther('10');
+
+  beforeEach(async function () {
+    await expect(
+      lensHub.createProfile({
+        to: userAddress,
+        handle: MOCK_PROFILE_HANDLE,
+        imageURI: MOCK_PROFILE_URI,
+        followModule: ZERO_ADDRESS,
+        followModuleData: [],
+        followNFTURI: MOCK_FOLLOW_NFT_URI,
+      })
+    ).to.not.be.reverted;
+    await expect(
+      lensHub.connect(governance).whitelistCollectModule(bctRetireCollectModule.address, true)
+    ).to.not.be.reverted;
+    await expect(
+      moduleGlobals.connect(governance).whitelistCurrency(currency.address, true)
+    ).to.not.be.reverted;
+  });
+
+  context('Negatives', function () {
+    context('Publication Creation', function () {
+      it('user should fail to post with BCT retire collect module using unwhitelisted currency', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16'],
+          [DEFAULT_COLLECT_PRICE, userTwoAddress, userAddress, REFERRAL_FEE_BPS]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: bctRetireCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with BCT retire collect module using zero recipient', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16'],
+          [DEFAULT_COLLECT_PRICE, currency.address, ZERO_ADDRESS, REFERRAL_FEE_BPS]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: bctRetireCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with BCT retire collect module using referral fee greater than max BPS', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16'],
+          [DEFAULT_COLLECT_PRICE, currency.address, userAddress, 10001]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: bctRetireCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with BCT retire collect module using amount lower than max BPS', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16'],
+          [9999, currency.address, userAddress, REFERRAL_FEE_BPS]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: bctRetireCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+    });
+
+    context('Collecting', function () {
+      beforeEach(async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'address', 'address', 'uint16'],
+          [DEFAULT_COLLECT_PRICE, currency.address, userAddress, REFERRAL_FEE_BPS]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: bctRetireCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+      });
+
+      it('UserTwo should fail to collect without following', async function () {
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.FOLLOW_INVALID);
+      });
+
+      it('UserTwo should fail to collect passing a different expected price in data', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE.div(2)]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should fail to collect passing a different expected currency in data', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(['address', 'uint256'], [userAddress, DEFAULT_COLLECT_PRICE]);
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should fail to collect without first approving module with currency', async function () {
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.ERC20_TRANSFER_EXCEEDS_ALLOWANCE);
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror without following the original profile', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+              imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        const data = abiCoder.encode(['uint256'], [DEFAULT_COLLECT_PRICE]);
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.FOLLOW_INVALID
+        );
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror passing a different expected price in data', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+              imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE.div(2)]
+        );
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.MODULE_DATA_MISMATCH
+        );
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror passing a different expected currency in data', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+              imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(['address', 'uint256'], [userAddress, DEFAULT_COLLECT_PRICE]);
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.MODULE_DATA_MISMATCH
+        );
+      });
+    });
+  });
+
+  context('Scenarios', function () {
+    it('User should post with BCT retire collect module as the collect module and data, correct events should be emitted', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'address', 'address', 'uint16'],
+        [DEFAULT_COLLECT_PRICE, currency.address, userAddress, REFERRAL_FEE_BPS]
+      );
+      const tx = lensHub.post({
+        profileId: FIRST_PROFILE_ID,
+        contentURI: MOCK_URI,
+        collectModule: bctRetireCollectModule.address,
+        collectModuleData: collectModuleData,
+        referenceModule: ZERO_ADDRESS,
+        referenceModuleData: [],
+      });
+
+      const receipt = await waitForTx(tx);
+
+      expect(receipt.logs.length).to.eq(1);
+      matchEvent(receipt, 'PostCreated', [
+        FIRST_PROFILE_ID,
+        1,
+        MOCK_URI,
+        bctRetireCollectModule.address,
+        [collectModuleData],
+        ZERO_ADDRESS,
+        [],
+        await getTimestamp(),
+      ]);
+    });
+
+    it('User should post with the BCT retire collect module as the collect module and data, fetched publication data should be accurate', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'address', 'address', 'uint16'],
+        [DEFAULT_COLLECT_PRICE, currency.address, userAddress, REFERRAL_FEE_BPS]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: bctRetireCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+      const postTimestamp = await getTimestamp();
+
+      const fetchedData = await bctRetireCollectModule.getPublicationData(FIRST_PROFILE_ID, 1);
+      expect(fetchedData.amount).to.eq(DEFAULT_COLLECT_PRICE);
+      expect(fetchedData.recipient).to.eq(userAddress);
+      expect(fetchedData.currency).to.eq(currency.address);
+      expect(fetchedData.referralFee).to.eq(REFERRAL_FEE_BPS);
+    });
+
+    it('User should post with the BCT retire collect module as the collect module and data, user two follows, then collects and pays fee, fee distribution is valid', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'address', 'address', 'uint16'],
+        [DEFAULT_COLLECT_PRICE, currency.address, userAddress, REFERRAL_FEE_BPS]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: bctRetireCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(bctRetireCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount = 0; // since it was retired
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+      );
+      expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with the BCT retire collect module as the collect module and data, user two follows, then collects twice, fee distribution is valid', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'address', 'address', 'uint16'],
+        [DEFAULT_COLLECT_PRICE, currency.address, userAddress, REFERRAL_FEE_BPS]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: bctRetireCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(bctRetireCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount = 0; // since it was retired
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(BigNumber.from(DEFAULT_COLLECT_PRICE).mul(2))
+      );
+      expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount.mul(2));
+    });
+
+    it('User should post with the BCT retire collect module as the collect module and data, user two mirrors, follows, then collects from their mirror and pays fee, fee distribution is valid', async function () {
+      const secondProfileId = FIRST_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'address', 'address', 'uint16'],
+        [DEFAULT_COLLECT_PRICE, currency.address, userAddress, REFERRAL_FEE_BPS]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: bctRetireCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: secondProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(bctRetireCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedReferralAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .sub(expectedTreasuryAmount)
+        .mul(REFERRAL_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedReferrerAmount = BigNumber.from(MAX_UINT256)
+        .sub(DEFAULT_COLLECT_PRICE)
+        .add(expectedReferralAmount);
+      const expectedRecipientAmount = 0; // since it was retired
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(expectedReferrerAmount);
+      expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with the BCT retire collect module as the collect module and data, with no referral fee, user two mirrors, follows, then collects from their mirror and pays fee, fee distribution is valid', async function () {
+      const secondProfileId = FIRST_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'address', 'address', 'uint16'],
+        [DEFAULT_COLLECT_PRICE, currency.address, userAddress, 0]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: bctRetireCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: secondProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(bctRetireCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount = 0; // since it was retired
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+      );
+      expect(await currency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+  });
+});


### PR DESCRIPTION
Collaboration with @cujowolf

We leverage KlimaDAO's retirement aggregator contract to easily swap the provided `currency` for BCT and retire it in a single transaction. Supports all currently whitelisted currencies.

Includes appropriate beneficiary and retirement messages so that there is an on-chain record of the specific recipient's retirement activity from the fee

This PR is tested and ready, we just need to deploy the Module on Mumbai testnet

**NOTE: we decided to name the module `BCTRetireCollectModule` because BCT is just one of the carbon tokens in the ReFi space, and down the line users may prefer retiring with nature-based offsets (e.g. NCT or MCO2) rather than the mostly renewable energy credits in BCT**