### PR TITLE
Add AaveLimitedFeeCollectModule

### DIFF
--- a/contracts/core/modules/collect/AaveLimitedFeeCollectModule.sol
+++ b/contracts/core/modules/collect/AaveLimitedFeeCollectModule.sol
@@ -1,0 +1,234 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {ICollectModule} from '../../../interfaces/ICollectModule.sol';
+import {ILendingPool} from '../../../interfaces/ILendingPool.sol';
+import {Errors} from '../../../libraries/Errors.sol';
+import {FeeModuleBase} from '../FeeModuleBase.sol';
+import {ModuleBase} from '../ModuleBase.sol';
+import {FollowValidationModuleBase} from '../FollowValidationModuleBase.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC721} from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+
+/**
+ * @notice A struct containing the necessary data to execute collect actions on a publication.
+ *
+ * @param collectLimit The maximum number of collects for this publication.
+ * @param currentCollects The current number of collects for this publication.
+ * @param amount The collecting cost associated with this publication.
+ * @param recipient The recipient address associated with this publication.
+ * @param currency The currency associated with this publication.
+ * @param referralFee The referral fee associated with this publication.
+ */
+struct ProfilePublicationData {
+    uint256 collectLimit;
+    uint256 currentCollects;
+    uint256 amount;
+    address recipient;
+    address currency;
+    uint16 referralFee;
+}
+
+/**
+ * @title AaveLimitedFeeCollectModule
+ * @author Lens Protocol, WATCHPUG
+ *
+ * @notice Extend the LimitedFeeCollectModule to deposit all received fees into the Aave Polygon Market (if applicable for the asset) and send the resulting aTokens to the beneficiary.
+ */
+contract AaveLimitedFeeCollectModule is ICollectModule, FeeModuleBase, FollowValidationModuleBase {
+    using SafeERC20 for IERC20;
+
+    mapping(uint256 => mapping(uint256 => ProfilePublicationData))
+        internal _dataByPublicationByProfile;
+
+    address public immutable lendingPool;
+
+    address[] public reserves;
+
+    constructor(address hub, address moduleGlobals, address _lendingPool) FeeModuleBase(moduleGlobals) ModuleBase(hub) {
+        lendingPool = _lendingPool;
+
+        updateReserves();
+    }
+
+    /**
+     * @dev Anyone can call this function to update the list of reserves.
+     */
+    function updateReserves() public {
+        reserves = ILendingPool(lendingPool).getReservesList();
+    }
+
+    function _assetInReserves(address asset) internal view returns (bool) {
+        uint256 _reservesLength = reserves.length;
+
+        for (uint256 i = 0; i < _reservesLength; ++i) {
+            if (asset == reserves[i]) return true;
+        }
+    }
+
+    /**
+     * @notice This collect module levies a fee on collects and supports referrals. Thus, we need to decode data.
+     *
+     * @param data The arbitrary data parameter, decoded into:
+     *      uint256 collectLimit: The maximum amount of collects.
+     *      uint256 amount: The currency total amount to levy.
+     *      address currency: The currency address, must be internally whitelisted.
+     *      address recipient: The custom recipient address to direct earnings to.
+     *      uint16 referralFee: The referral fee to set.
+     *
+     * @return An abi encoded bytes parameter, which is the same as the passed data parameter.
+     */
+    function initializePublicationCollectModule(
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) external override onlyHub returns (bytes memory) {
+        (
+            uint256 collectLimit,
+            uint256 amount,
+            address currency,
+            address recipient,
+            uint16 referralFee
+        ) = abi.decode(data, (uint256, uint256, address, address, uint16));
+        if (
+            collectLimit == 0 ||
+            !_currencyWhitelisted(currency) ||
+            recipient == address(0) ||
+            referralFee > BPS_MAX ||
+            amount < BPS_MAX
+        ) revert Errors.InitParamsInvalid();
+
+        _dataByPublicationByProfile[profileId][pubId].collectLimit = collectLimit;
+        _dataByPublicationByProfile[profileId][pubId].amount = amount;
+        _dataByPublicationByProfile[profileId][pubId].currency = currency;
+        _dataByPublicationByProfile[profileId][pubId].recipient = recipient;
+        _dataByPublicationByProfile[profileId][pubId].referralFee = referralFee;
+
+        return data;
+    }
+
+    /**
+     * @dev Processes a collect by:
+     *  1. Ensuring the collector is a follower
+     *  2. Ensuring the collect does not pass the collect limit
+     *  3. Charging a fee
+     */
+    function processCollect(
+        uint256 referrerProfileId,
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) external override onlyHub {
+        _checkFollowValidity(profileId, collector);
+
+        if (
+            _dataByPublicationByProfile[profileId][pubId].currentCollects >=
+            _dataByPublicationByProfile[profileId][pubId].collectLimit
+        ) {
+            revert Errors.MintLimitExceeded();
+        } else {
+            _dataByPublicationByProfile[profileId][pubId].currentCollects++;
+            if (referrerProfileId == profileId) {
+                _processCollect(collector, profileId, pubId, data);
+            } else {
+                _processCollectWithReferral(referrerProfileId, collector, profileId, pubId, data);
+            }
+        }
+    }
+
+    /**
+     * @notice Returns the publication data for a given publication, or an empty struct if that publication was not
+     * initialized with this module.
+     *
+     * @param profileId The token ID of the profile mapped to the publication to query.
+     * @param pubId The publication ID of the publication to query.
+     *
+     * @return The ProfilePublicationData struct mapped to that publication.
+     */
+    function getPublicationData(uint256 profileId, uint256 pubId)
+        external
+        view
+        returns (ProfilePublicationData memory)
+    {
+        return _dataByPublicationByProfile[profileId][pubId];
+    }
+
+    function _processCollect(
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) internal {
+        uint256 amount = _dataByPublicationByProfile[profileId][pubId].amount;
+        address currency = _dataByPublicationByProfile[profileId][pubId].currency;
+        _validateDataIsExpected(data, currency, amount);
+
+        (address treasury, uint16 treasuryFee) = _treasuryData();
+        address recipient = _dataByPublicationByProfile[profileId][pubId].recipient;
+        uint256 treasuryAmount = (amount * treasuryFee) / BPS_MAX;
+        uint256 adjustedAmount = amount - treasuryAmount;
+
+        _transferFromAndDepositToAaveIfApplicable(currency, collector, recipient, adjustedAmount);
+        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+    }
+
+
+    function _transferFromAndDepositToAaveIfApplicable(
+        address currency,
+        address from,
+        address beneficiary,
+        uint256 amount
+    ) internal {
+        if (_assetInReserves(currency)) {
+            IERC20(currency).safeTransferFrom(from, address(this), amount);
+            IERC20(currency).approve(address(lendingPool), amount);
+            ILendingPool(lendingPool).deposit(currency, amount, beneficiary, 0);
+        } else {
+            IERC20(currency).safeTransferFrom(from, beneficiary, amount);
+        }
+    }
+
+    function _processCollectWithReferral(
+        uint256 referrerProfileId,
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) internal {
+        uint256 amount = _dataByPublicationByProfile[profileId][pubId].amount;
+        address currency = _dataByPublicationByProfile[profileId][pubId].currency;
+        _validateDataIsExpected(data, currency, amount);
+
+        uint256 referralFee = _dataByPublicationByProfile[profileId][pubId].referralFee;
+        address treasury;
+        uint256 treasuryAmount;
+
+        // Avoids stack too deep
+        {
+            uint16 treasuryFee;
+            (treasury, treasuryFee) = _treasuryData();
+            treasuryAmount = (amount * treasuryFee) / BPS_MAX;
+        }
+
+        uint256 adjustedAmount = amount - treasuryAmount;
+
+        if (referralFee != 0) {
+            // The reason we levy the referral fee on the adjusted amount is so that referral fees
+            // don't bypass the treasury fee, in essence referrals pay their fair share to the treasury.
+            uint256 referralAmount = (adjustedAmount * referralFee) / BPS_MAX;
+            adjustedAmount = adjustedAmount - referralAmount;
+
+            address referralRecipient = IERC721(HUB).ownerOf(referrerProfileId);
+
+            IERC20(currency).safeTransferFrom(collector, referralRecipient, referralAmount);
+        }
+        address recipient = _dataByPublicationByProfile[profileId][pubId].recipient;
+
+        _transferFromAndDepositToAaveIfApplicable(currency, collector, recipient, adjustedAmount);
+
+        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+    }
+}

--- a/contracts/interfaces/ILendingPool.sol
+++ b/contracts/interfaces/ILendingPool.sol
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: agpl-3.0
+pragma solidity 0.8.10;
+pragma experimental ABIEncoderV2;
+
+interface ILendingPool {
+  /**
+   * @dev Emitted on deposit()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address initiating the deposit
+   * @param onBehalfOf The beneficiary of the deposit, receiving the aTokens
+   * @param amount The amount deposited
+   * @param referral The referral code used
+   **/
+  event Deposit(
+    address indexed reserve,
+    address user,
+    address indexed onBehalfOf,
+    uint256 amount,
+    uint16 indexed referral
+  );
+
+  /**
+   * @dev Emitted on withdraw()
+   * @param reserve The address of the underlyng asset being withdrawn
+   * @param user The address initiating the withdrawal, owner of aTokens
+   * @param to Address that will receive the underlying
+   * @param amount The amount to be withdrawn
+   **/
+  event Withdraw(address indexed reserve, address indexed user, address indexed to, uint256 amount);
+
+  /**
+   * @dev Emitted on borrow() and flashLoan() when debt needs to be opened
+   * @param reserve The address of the underlying asset being borrowed
+   * @param user The address of the user initiating the borrow(), receiving the funds on borrow() or just
+   * initiator of the transaction on flashLoan()
+   * @param onBehalfOf The address that will be getting the debt
+   * @param amount The amount borrowed out
+   * @param borrowRateMode The rate mode: 1 for Stable, 2 for Variable
+   * @param borrowRate The numeric rate at which the user has borrowed
+   * @param referral The referral code used
+   **/
+  event Borrow(
+    address indexed reserve,
+    address user,
+    address indexed onBehalfOf,
+    uint256 amount,
+    uint256 borrowRateMode,
+    uint256 borrowRate,
+    uint16 indexed referral
+  );
+
+  /**
+   * @dev Emitted on repay()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The beneficiary of the repayment, getting his debt reduced
+   * @param repayer The address of the user initiating the repay(), providing the funds
+   * @param amount The amount repaid
+   **/
+  event Repay(
+    address indexed reserve,
+    address indexed user,
+    address indexed repayer,
+    uint256 amount
+  );
+
+  /**
+   * @dev Emitted on swapBorrowRateMode()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address of the user swapping his rate mode
+   * @param rateMode The rate mode that the user wants to swap to
+   **/
+  event Swap(address indexed reserve, address indexed user, uint256 rateMode);
+
+  /**
+   * @dev Emitted on setUserUseReserveAsCollateral()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address of the user enabling the usage as collateral
+   **/
+  event ReserveUsedAsCollateralEnabled(address indexed reserve, address indexed user);
+
+  /**
+   * @dev Emitted on setUserUseReserveAsCollateral()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address of the user enabling the usage as collateral
+   **/
+  event ReserveUsedAsCollateralDisabled(address indexed reserve, address indexed user);
+
+  /**
+   * @dev Emitted on rebalanceStableBorrowRate()
+   * @param reserve The address of the underlying asset of the reserve
+   * @param user The address of the user for which the rebalance has been executed
+   **/
+  event RebalanceStableBorrowRate(address indexed reserve, address indexed user);
+
+  /**
+   * @dev Emitted on flashLoan()
+   * @param target The address of the flash loan receiver contract
+   * @param initiator The address initiating the flash loan
+   * @param asset The address of the asset being flash borrowed
+   * @param amount The amount flash borrowed
+   * @param premium The fee flash borrowed
+   * @param referralCode The referral code used
+   **/
+  event FlashLoan(
+    address indexed target,
+    address indexed initiator,
+    address indexed asset,
+    uint256 amount,
+    uint256 premium,
+    uint16 referralCode
+  );
+
+  /**
+   * @dev Emitted when the pause is triggered.
+   */
+  event Paused();
+
+  /**
+   * @dev Emitted when the pause is lifted.
+   */
+  event Unpaused();
+
+  /**
+   * @dev Emitted when a borrower is liquidated. This event is emitted by the LendingPool via
+   * LendingPoolCollateral manager using a DELEGATECALL
+   * This allows to have the events in the generated ABI for LendingPool.
+   * @param collateralAsset The address of the underlying asset used as collateral, to receive as result of the liquidation
+   * @param debtAsset The address of the underlying borrowed asset to be repaid with the liquidation
+   * @param user The address of the borrower getting liquidated
+   * @param debtToCover The debt amount of borrowed `asset` the liquidator wants to cover
+   * @param liquidatedCollateralAmount The amount of collateral received by the liiquidator
+   * @param liquidator The address of the liquidator
+   * @param receiveAToken `true` if the liquidators wants to receive the collateral aTokens, `false` if he wants
+   * to receive the underlying collateral asset directly
+   **/
+  event LiquidationCall(
+    address indexed collateralAsset,
+    address indexed debtAsset,
+    address indexed user,
+    uint256 debtToCover,
+    uint256 liquidatedCollateralAmount,
+    address liquidator,
+    bool receiveAToken
+  );
+
+  /**
+   * @dev Emitted when the state of a reserve is updated. NOTE: This event is actually declared
+   * in the ReserveLogic library and emitted in the updateInterestRates() function. Since the function is internal,
+   * the event will actually be fired by the LendingPool contract. The event is therefore replicated here so it
+   * gets added to the LendingPool ABI
+   * @param reserve The address of the underlying asset of the reserve
+   * @param liquidityRate The new liquidity rate
+   * @param stableBorrowRate The new stable borrow rate
+   * @param variableBorrowRate The new variable borrow rate
+   * @param liquidityIndex The new liquidity index
+   * @param variableBorrowIndex The new variable borrow index
+   **/
+  event ReserveDataUpdated(
+    address indexed reserve,
+    uint256 liquidityRate,
+    uint256 stableBorrowRate,
+    uint256 variableBorrowRate,
+    uint256 liquidityIndex,
+    uint256 variableBorrowIndex
+  );
+
+  /**
+   * @dev Deposits an `amount` of underlying asset into the reserve, receiving in return overlying aTokens.
+   * - E.g. User deposits 100 USDC and gets in return 100 aUSDC
+   * @param asset The address of the underlying asset to deposit
+   * @param amount The amount to be deposited
+   * @param onBehalfOf The address that will receive the aTokens, same as msg.sender if the user
+   *   wants to receive them on his own wallet, or a different address if the beneficiary of aTokens
+   *   is a different wallet
+   * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   **/
+  function deposit(
+    address asset,
+    uint256 amount,
+    address onBehalfOf,
+    uint16 referralCode
+  ) external;
+
+  /**
+   * @dev Withdraws an `amount` of underlying asset from the reserve, burning the equivalent aTokens owned
+   * E.g. User has 100 aUSDC, calls withdraw() and receives 100 USDC, burning the 100 aUSDC
+   * @param asset The address of the underlying asset to withdraw
+   * @param amount The underlying amount to be withdrawn
+   *   - Send the value type(uint256).max in order to withdraw the whole aToken balance
+   * @param to Address that will receive the underlying, same as msg.sender if the user
+   *   wants to receive it on his own wallet, or a different address if the beneficiary is a
+   *   different wallet
+   * @return The final amount withdrawn
+   **/
+  function withdraw(
+    address asset,
+    uint256 amount,
+    address to
+  ) external returns (uint256);
+
+  /**
+   * @dev Allows users to borrow a specific `amount` of the reserve underlying asset, provided that the borrower
+   * already deposited enough collateral, or he was given enough allowance by a credit delegator on the
+   * corresponding debt token (StableDebtToken or VariableDebtToken)
+   * - E.g. User borrows 100 USDC passing as `onBehalfOf` his own address, receiving the 100 USDC in his wallet
+   *   and 100 stable/variable debt tokens, depending on the `interestRateMode`
+   * @param asset The address of the underlying asset to borrow
+   * @param amount The amount to be borrowed
+   * @param interestRateMode The interest rate mode at which the user wants to borrow: 1 for Stable, 2 for Variable
+   * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   * @param onBehalfOf Address of the user who will receive the debt. Should be the address of the borrower itself
+   * calling the function if he wants to borrow against his own collateral, or the address of the credit delegator
+   * if he has been given credit delegation allowance
+   **/
+  function borrow(
+    address asset,
+    uint256 amount,
+    uint256 interestRateMode,
+    uint16 referralCode,
+    address onBehalfOf
+  ) external;
+
+  /**
+   * @notice Repays a borrowed `amount` on a specific reserve, burning the equivalent debt tokens owned
+   * - E.g. User repays 100 USDC, burning 100 variable/stable debt tokens of the `onBehalfOf` address
+   * @param asset The address of the borrowed underlying asset previously borrowed
+   * @param amount The amount to repay
+   * - Send the value type(uint256).max in order to repay the whole debt for `asset` on the specific `debtMode`
+   * @param rateMode The interest rate mode at of the debt the user wants to repay: 1 for Stable, 2 for Variable
+   * @param onBehalfOf Address of the user who will get his debt reduced/removed. Should be the address of the
+   * user calling the function if he wants to reduce/remove his own debt, or the address of any other
+   * other borrower whose debt should be removed
+   * @return The final amount repaid
+   **/
+  function repay(
+    address asset,
+    uint256 amount,
+    uint256 rateMode,
+    address onBehalfOf
+  ) external returns (uint256);
+
+  /**
+   * @dev Allows a borrower to swap his debt between stable and variable mode, or viceversa
+   * @param asset The address of the underlying asset borrowed
+   * @param rateMode The rate mode that the user wants to swap to
+   **/
+  function swapBorrowRateMode(address asset, uint256 rateMode) external;
+
+  /**
+   * @dev Rebalances the stable interest rate of a user to the current stable rate defined on the reserve.
+   * - Users can be rebalanced if the following conditions are satisfied:
+   *     1. Usage ratio is above 95%
+   *     2. the current deposit APY is below REBALANCE_UP_THRESHOLD * maxVariableBorrowRate, which means that too much has been
+   *        borrowed at a stable rate and depositors are not earning enough
+   * @param asset The address of the underlying asset borrowed
+   * @param user The address of the user to be rebalanced
+   **/
+  function rebalanceStableBorrowRate(address asset, address user) external;
+
+  /**
+   * @dev Allows depositors to enable/disable a specific deposited asset as collateral
+   * @param asset The address of the underlying asset deposited
+   * @param useAsCollateral `true` if the user wants to use the deposit as collateral, `false` otherwise
+   **/
+  function setUserUseReserveAsCollateral(address asset, bool useAsCollateral) external;
+
+  /**
+   * @dev Function to liquidate a non-healthy position collateral-wise, with Health Factor below 1
+   * - The caller (liquidator) covers `debtToCover` amount of debt of the user getting liquidated, and receives
+   *   a proportionally amount of the `collateralAsset` plus a bonus to cover market risk
+   * @param collateralAsset The address of the underlying asset used as collateral, to receive as result of the liquidation
+   * @param debtAsset The address of the underlying borrowed asset to be repaid with the liquidation
+   * @param user The address of the borrower getting liquidated
+   * @param debtToCover The debt amount of borrowed `asset` the liquidator wants to cover
+   * @param receiveAToken `true` if the liquidators wants to receive the collateral aTokens, `false` if he wants
+   * to receive the underlying collateral asset directly
+   **/
+  function liquidationCall(
+    address collateralAsset,
+    address debtAsset,
+    address user,
+    uint256 debtToCover,
+    bool receiveAToken
+  ) external;
+
+  /**
+   * @dev Allows smartcontracts to access the liquidity of the pool within one transaction,
+   * as long as the amount taken plus a fee is returned.
+   * IMPORTANT There are security concerns for developers of flashloan receiver contracts that must be kept into consideration.
+   * For further details please visit https://developers.aave.com
+   * @param receiverAddress The address of the contract receiving the funds, implementing the IFlashLoanReceiver interface
+   * @param assets The addresses of the assets being flash-borrowed
+   * @param amounts The amounts amounts being flash-borrowed
+   * @param modes Types of the debt to open if the flash loan is not returned:
+   *   0 -> Don't open any debt, just revert if funds can't be transferred from the receiver
+   *   1 -> Open debt at stable rate for the value of the amount flash-borrowed to the `onBehalfOf` address
+   *   2 -> Open debt at variable rate for the value of the amount flash-borrowed to the `onBehalfOf` address
+   * @param onBehalfOf The address  that will receive the debt in the case of using on `modes` 1 or 2
+   * @param params Variadic packed params to pass to the receiver as extra information
+   * @param referralCode Code used to register the integrator originating the operation, for potential rewards.
+   *   0 if the action is executed directly by the user, without any middle-man
+   **/
+  function flashLoan(
+    address receiverAddress,
+    address[] calldata assets,
+    uint256[] calldata amounts,
+    uint256[] calldata modes,
+    address onBehalfOf,
+    bytes calldata params,
+    uint16 referralCode
+  ) external;
+
+  /**
+   * @dev Returns the user account data across all the reserves
+   * @param user The address of the user
+   * @return totalCollateralETH the total collateral in ETH of the user
+   * @return totalDebtETH the total debt in ETH of the user
+   * @return availableBorrowsETH the borrowing power left of the user
+   * @return currentLiquidationThreshold the liquidation threshold of the user
+   * @return ltv the loan to value of the user
+   * @return healthFactor the current health factor of the user
+   **/
+  function getUserAccountData(address user)
+    external
+    view
+    returns (
+      uint256 totalCollateralETH,
+      uint256 totalDebtETH,
+      uint256 availableBorrowsETH,
+      uint256 currentLiquidationThreshold,
+      uint256 ltv,
+      uint256 healthFactor
+    );
+
+  function initReserve(
+    address reserve,
+    address aTokenAddress,
+    address stableDebtAddress,
+    address variableDebtAddress,
+    address interestRateStrategyAddress
+  ) external;
+
+  function setReserveInterestRateStrategyAddress(address reserve, address rateStrategyAddress)
+    external;
+
+  function setConfiguration(address reserve, uint256 configuration) external;
+
+  /**
+   * @dev Returns the normalized income normalized income of the reserve
+   * @param asset The address of the underlying asset of the reserve
+   * @return The reserve's normalized income
+   */
+  function getReserveNormalizedIncome(address asset) external view returns (uint256);
+
+  /**
+   * @dev Returns the normalized variable debt per unit of asset
+   * @param asset The address of the underlying asset of the reserve
+   * @return The reserve normalized variable debt
+   */
+  function getReserveNormalizedVariableDebt(address asset) external view returns (uint256);
+
+
+  function finalizeTransfer(
+    address asset,
+    address from,
+    address to,
+    uint256 amount,
+    uint256 balanceFromAfter,
+    uint256 balanceToBefore
+  ) external;
+
+  function getReservesList() external view returns (address[] memory);
+
+  function setPause(bool val) external;
+
+  function paused() external view returns (bool);
+}

--- a/contracts/mocks/ACurrency.sol
+++ b/contracts/mocks/ACurrency.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {ERC20} from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+contract ACurrency is ERC20('ACurrency', 'aCRNC') {
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/mocks/MockLendingPool.sol
+++ b/contracts/mocks/MockLendingPool.sol
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+
+interface IAToken {
+    function mint(address to, uint256 amount) external;
+}
+
+contract MockLendingPool {
+    address[] public reserves;
+    address public aTokenAddress;
+
+    constructor(
+        address _reserve,
+        address _aTokenAddress)
+    {
+        reserves.push(_reserve);
+        aTokenAddress = _aTokenAddress;
+    }
+
+    function getReservesList() external view returns (address[] memory) {
+        return reserves;
+    }
+
+    function deposit(
+        address asset,
+        uint256 amount,
+        address onBehalfOf,
+        uint16 referralCode
+    ) external {
+        IERC20(asset).transferFrom(msg.sender, aTokenAddress, amount);
+
+        IAToken(aTokenAddress).mint(onBehalfOf, amount);
+    }
+}

--- a/test/__setup.spec.ts
+++ b/test/__setup.spec.ts
@@ -1,4 +1,4 @@
-import { AbiCoder } from '@ethersproject/contracts/node_modules/@ethersproject/abi';
+import { AbiCoder } from '@ethersproject/abi';
 import { parseEther } from '@ethersproject/units';
 import '@nomiclabs/hardhat-ethers';
 import { expect, use } from 'chai';
@@ -11,6 +11,8 @@ import {
   CollectNFT__factory,
   Currency,
   Currency__factory,
+  ACurrency,
+  ACurrency__factory,
   EmptyCollectModule,
   EmptyCollectModule__factory,
   Events,
@@ -29,8 +31,12 @@ import {
   LensHub__factory,
   LimitedFeeCollectModule,
   LimitedFeeCollectModule__factory,
+  AaveLimitedFeeCollectModule,
+  AaveLimitedFeeCollectModule__factory,
   LimitedTimedFeeCollectModule,
   LimitedTimedFeeCollectModule__factory,
+  MockLendingPool,
+  MockLendingPool__factory,
   MockFollowModule,
   MockFollowModule__factory,
   MockReferenceModule,
@@ -88,6 +94,9 @@ export let testWallet: Wallet;
 export let lensHubImpl: LensHub;
 export let lensHub: LensHub;
 export let currency: Currency;
+export let aCurrency: ACurrency;
+export let currencyTwo: Currency;
+export let lendingPool: MockLendingPool;
 export let abiCoder: AbiCoder;
 export let mockModuleData: BytesLike;
 export let hubLibs: LensHubLibraryAddresses;
@@ -103,6 +112,7 @@ export let timedFeeCollectModule: TimedFeeCollectModule;
 export let emptyCollectModule: EmptyCollectModule;
 export let revertCollectModule: RevertCollectModule;
 export let limitedFeeCollectModule: LimitedFeeCollectModule;
+export let aaveLimitedFeeCollectModule: AaveLimitedFeeCollectModule;
 export let limitedTimedFeeCollectModule: LimitedTimedFeeCollectModule;
 
 // Follow
@@ -187,6 +197,14 @@ before(async function () {
 
   // Currency
   currency = await new Currency__factory(deployer).deploy();
+  currencyTwo = await new Currency__factory(deployer).deploy();
+  aCurrency = await new ACurrency__factory(deployer).deploy();
+
+  // LendingPool
+  lendingPool = await new MockLendingPool__factory(deployer).deploy(
+    currency.address,
+    aCurrency.address
+  );
 
   // Modules
   emptyCollectModule = await new EmptyCollectModule__factory(deployer).deploy(lensHub.address);
@@ -202,6 +220,11 @@ before(async function () {
   limitedFeeCollectModule = await new LimitedFeeCollectModule__factory(deployer).deploy(
     lensHub.address,
     moduleGlobals.address
+  );
+  aaveLimitedFeeCollectModule = await new AaveLimitedFeeCollectModule__factory(deployer).deploy(
+    lensHub.address,
+    moduleGlobals.address,
+    lendingPool.address
   );
   limitedTimedFeeCollectModule = await new LimitedTimedFeeCollectModule__factory(deployer).deploy(
     lensHub.address,
@@ -233,6 +256,7 @@ before(async function () {
 
   expect(lensHub).to.not.be.undefined;
   expect(currency).to.not.be.undefined;
+  expect(currencyTwo).to.not.be.undefined;
   expect(timedFeeCollectModule).to.not.be.undefined;
   expect(mockFollowModule).to.not.be.undefined;
   expect(mockReferenceModule).to.not.be.undefined;

--- a/test/modules/collect/aave-limited-fee-collect-module.spec.ts
+++ b/test/modules/collect/aave-limited-fee-collect-module.spec.ts
@@ -1,0 +1,724 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { parseEther } from '@ethersproject/units';
+import '@nomiclabs/hardhat-ethers';
+import { expect } from 'chai';
+import { MAX_UINT256, ZERO_ADDRESS } from '../../helpers/constants';
+import { ERRORS } from '../../helpers/errors';
+import { getTimestamp, matchEvent, waitForTx } from '../../helpers/utils';
+import {
+  abiCoder,
+  BPS_MAX,
+  currency,
+  currencyTwo,
+  aCurrency,
+  FIRST_PROFILE_ID,
+  governance,
+  lensHub,
+  aaveLimitedFeeCollectModule,
+  makeSuiteCleanRoom,
+  MOCK_FOLLOW_NFT_URI,
+  MOCK_PROFILE_HANDLE,
+  MOCK_PROFILE_URI,
+  MOCK_URI,
+  moduleGlobals,
+  REFERRAL_FEE_BPS,
+  treasuryAddress,
+  TREASURY_FEE_BPS,
+  userAddress,
+  userTwo,
+  userTwoAddress,
+} from '../../__setup.spec';
+
+makeSuiteCleanRoom('AAVE Limited Fee Collect Module', function () {
+  const DEFAULT_COLLECT_PRICE = parseEther('10');
+  const DEFAULT_COLLECT_LIMIT = 3;
+
+  beforeEach(async function () {
+    await expect(
+      lensHub.createProfile({
+        to: userAddress,
+        handle: MOCK_PROFILE_HANDLE,
+        imageURI: MOCK_PROFILE_URI,
+        followModule: ZERO_ADDRESS,
+        followModuleData: [],
+        followNFTURI: MOCK_FOLLOW_NFT_URI,
+      })
+    ).to.not.be.reverted;
+    await expect(
+      lensHub.connect(governance).whitelistCollectModule(aaveLimitedFeeCollectModule.address, true)
+    ).to.not.be.reverted;
+    await expect(
+      moduleGlobals.connect(governance).whitelistCurrency(currency.address, true)
+    ).to.not.be.reverted;
+    await expect(
+      moduleGlobals.connect(governance).whitelistCurrency(currencyTwo.address, true)
+    ).to.not.be.reverted;
+  });
+
+  context('Negatives', function () {
+    context('Publication Creation', function () {
+      it('user should fail to post with aave limited fee collect module using zero collect limit', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [0, DEFAULT_COLLECT_PRICE, currency.address, userAddress, REFERRAL_FEE_BPS]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: aaveLimitedFeeCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with aave limited fee collect module using unwhitelisted currency', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            DEFAULT_COLLECT_PRICE,
+            userTwoAddress,
+            userAddress,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: aaveLimitedFeeCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with aave limited fee collect module using zero recipient', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            ZERO_ADDRESS,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: aaveLimitedFeeCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with aave limited fee collect module using referral fee greater than max BPS', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [DEFAULT_COLLECT_LIMIT, DEFAULT_COLLECT_PRICE, currency.address, userAddress, 10001]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: aaveLimitedFeeCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with aave limited fee collect module using amount lower than max BPS', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [DEFAULT_COLLECT_LIMIT, 9999, currency.address, userAddress, REFERRAL_FEE_BPS]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: aaveLimitedFeeCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+    });
+
+    context('Collecting', function () {
+      beforeEach(async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: aaveLimitedFeeCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+      });
+
+      it('UserTwo should fail to collect without following', async function () {
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.FOLLOW_INVALID);
+      });
+
+      it('UserTwo should fail to collect passing a different expected price in data', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE.div(2)]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should fail to collect passing a different expected currency in data', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(['address', 'uint256'], [userAddress, DEFAULT_COLLECT_PRICE]);
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should fail to collect without first approving module with currency', async function () {
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.ERC20_TRANSFER_EXCEEDS_ALLOWANCE);
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror without following the original profile', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.FOLLOW_INVALID
+        );
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror passing a different expected price in data', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE.div(2)]
+        );
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.MODULE_DATA_MISMATCH
+        );
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror passing a different expected currency in data', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        const data = abiCoder.encode(['address', 'uint256'], [userAddress, DEFAULT_COLLECT_PRICE]);
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.MODULE_DATA_MISMATCH
+        );
+      });
+    });
+  });
+
+  context('Scenarios', function () {
+    it('User should post with aave limited fee collect module as the collect module and data, correct events should be emitted', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      const tx = lensHub.post({
+        profileId: FIRST_PROFILE_ID,
+        contentURI: MOCK_URI,
+        collectModule: aaveLimitedFeeCollectModule.address,
+        collectModuleData: collectModuleData,
+        referenceModule: ZERO_ADDRESS,
+        referenceModuleData: [],
+      });
+
+      const receipt = await waitForTx(tx);
+
+      expect(receipt.logs.length).to.eq(1);
+      matchEvent(receipt, 'PostCreated', [
+        FIRST_PROFILE_ID,
+        1,
+        MOCK_URI,
+        aaveLimitedFeeCollectModule.address,
+        collectModuleData,
+        ZERO_ADDRESS,
+        [],
+        await getTimestamp(),
+      ]);
+    });
+
+    it('User should post with aave limited fee collect module as the collect module and data, fetched publication data should be accurate', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: aaveLimitedFeeCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      const fetchedData = await aaveLimitedFeeCollectModule.getPublicationData(FIRST_PROFILE_ID, 1);
+      expect(fetchedData.collectLimit).to.eq(DEFAULT_COLLECT_LIMIT);
+      expect(fetchedData.amount).to.eq(DEFAULT_COLLECT_PRICE);
+      expect(fetchedData.recipient).to.eq(userAddress);
+      expect(fetchedData.currency).to.eq(currency.address);
+      expect(fetchedData.referralFee).to.eq(REFERRAL_FEE_BPS);
+    });
+
+    it('User should post with aave limited fee collect module as the collect module and data, user two follows, then collects and pays fee with currencyTwo, fee distribution is by currencyTwo', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currencyTwo.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: aaveLimitedFeeCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currencyTwo.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currencyTwo.connect(userTwo).approve(aaveLimitedFeeCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currencyTwo.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      expect(await currencyTwo.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+      );
+      expect(await currencyTwo.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currencyTwo.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with aave limited fee collect module as the collect module and data, user two follows, then collects and pays fee, fee distribution is valid', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: aaveLimitedFeeCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(aaveLimitedFeeCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+      );
+      expect(await aCurrency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with aave limited fee collect module as the collect module and data, user two follows, then collects twice, fee distribution is valid', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: aaveLimitedFeeCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(aaveLimitedFeeCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(BigNumber.from(DEFAULT_COLLECT_PRICE).mul(2))
+      );
+      expect(await aCurrency.balanceOf(userAddress)).to.eq(expectedRecipientAmount.mul(2));
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount.mul(2));
+    });
+
+    it('User should post with aave limited fee collect module as the collect module and data, user two mirrors, follows, then collects from their mirror and pays fee, fee distribution is valid', async function () {
+      const secondProfileId = FIRST_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: aaveLimitedFeeCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: secondProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(aaveLimitedFeeCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedReferralAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .sub(expectedTreasuryAmount)
+        .mul(REFERRAL_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedReferrerAmount = BigNumber.from(MAX_UINT256)
+        .sub(DEFAULT_COLLECT_PRICE)
+        .add(expectedReferralAmount);
+      const expectedRecipientAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .sub(expectedTreasuryAmount)
+        .sub(expectedReferralAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(expectedReferrerAmount);
+      expect(await aCurrency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with aave limited fee collect module as the collect module and data, with no referral fee, user two mirrors, follows, then collects from their mirror and pays fee, fee distribution is valid', async function () {
+      const secondProfileId = FIRST_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [DEFAULT_COLLECT_LIMIT, DEFAULT_COLLECT_PRICE, currency.address, userAddress, 0]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: aaveLimitedFeeCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: secondProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(aaveLimitedFeeCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+      );
+      expect(await aCurrency.balanceOf(userAddress)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with aave limited fee collect module as the collect module and data, user two mirrors, follows, then collects once from the original, twice from the mirror, and fails to collect a third time from either the mirror or the original', async function () {
+      const secondProfileId = FIRST_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: aaveLimitedFeeCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: secondProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(aaveLimitedFeeCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.be.revertedWith(
+        ERRORS.MINT_LIMIT_EXCEEDED
+      );
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+        ERRORS.MINT_LIMIT_EXCEEDED
+      );
+    });
+  });
+});


### PR DESCRIPTION
Extend the LimitedFeeCollectModule to deposit all received fees into the Aave Polygon Market (if applicable for the asset) and send the resulting aTokens to the beneficiary.