### PR TITLE
Document addresses for the default Hardhat accounts

### DIFF
--- a/helpers/test-wallets.ts
+++ b/helpers/test-wallets.ts
@@ -2,34 +2,42 @@ const balance = '1000000000000000000000000';
 
 export const accounts = [
   {
+    // 0xc783df8a850f42e7f7e57013759c285caa701eb6
     secretKey: '0xc5e8f61d1ab959b397eecc0a37a6517b8e67a0e7cf1f4bce5591f3ed80199122',
     balance,
   },
   {
+    // 0xead9c93b79ae7c1591b1fb5323bd777e86e150d4
     secretKey: '0xd49743deccbccc5dc7baa8e69e5be03298da8688a15dd202e20f15d5e0e9a9fb',
     balance,
   },
   {
+    // 0xe5904695748fe4a84b40b3fc79de2277660bd1d3
     secretKey: '0x23c601ae397441f3ef6f1075dcb0031ff17fb079837beadaf3c84d96c6f3e569',
     balance,
   },
   {
+    // 0x92561f28ec438ee9831d00d1d59fbdc981b762b2
     secretKey: '0xee9d129c1997549ee09c0757af5939b2483d80ad649a0eda68e8b0357ad11131',
     balance,
   },
   {
+    // 0x2ffd013aaa7b5a7da93336c2251075202b33fb2b
     secretKey: '0x87630b2d1de0fbd5044eb6891b3d9d98c34c8d310c852f98550ba774480e47cc',
     balance,
   },
   {
+    // 0x9fc9c2dfba3b6cf204c37a5f690619772b926e39
     secretKey: '0x275cc4a2bfd4f612625204a20a2280ab53a6da2d14860c47a9f5affe58ad86d4',
     balance,
   },
   {
+    // 0xad9fbd38281f615e7df3def2aad18935a9e0ffee
     secretKey: '0xaee25d55ce586148a853ca83fdfacaf7bc42d5762c6e7187e6f8e822d8e6a650',
     balance,
   },
   {
+    // 0x8bffc896d42f07776561a5814d6e4240950d6d3a
     secretKey: '0xa2e0097c961c67ec197b6865d7ecea6caffc68ebeb00e6050368c8f67fc9c588',
     balance,
   },


### PR DESCRIPTION
Lens uses a different set of accounts from the Hardhat default. We should document the addresses of these accounts somewhere to save time for dapp developers who need to add the account to their local Metamask.

To start off, I've just put the information here for future reference. 