### PR TITLE
add AlterateTokenCollectModule

### DIFF
--- a/contracts/core/modules/collect/AlterateTokenCollectModule.sol
+++ b/contracts/core/modules/collect/AlterateTokenCollectModule.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {ICollectModule} from '../../../interfaces/ICollectModule.sol';
+import {Errors} from '../../../libraries/Errors.sol';
+import {FeeModuleBase} from '../FeeModuleBase.sol';
+import {ModuleBase} from '../ModuleBase.sol';
+import {FollowValidationModuleBase} from '../FollowValidationModuleBase.sol';
+import {IERC20} from '@openzeppelin/contracts/token/ERC20/IERC20.sol';
+import {SafeERC20} from '@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol';
+import {IERC721} from '@openzeppelin/contracts/token/ERC721/IERC721.sol';
+
+import '../../../misc/SwapDelegatorFactory.sol';
+
+/**
+ * @notice A struct containing the necessary data to execute collect actions on a publication.
+ *
+ * @param collectLimit The maximum number of collects for this publication.
+ * @param currentCollects The current number of collects for this publication.
+ * @param amount The collecting cost associated with this publication.
+ * @param recipient The recipient address associated with this publication.
+ * @param currency The currency associated with this publication.
+ * @param outputCurrency The outputCurrency associated with this publication.
+ * @param referralFee The referral fee associated with this publication.
+ */
+struct ProfilePublicationData {
+    uint256 collectLimit;
+    uint256 currentCollects;
+    uint256 amount;
+    address recipient;
+    address currency;
+    address outputCurrency;
+    uint16 referralFee;
+}
+
+struct SwapByQuoteData {
+    address sellTokenAddress;
+    uint256 amountToSell;
+    address buyTokenAddress;
+    uint256 minimumAmountReceived;
+    address allowanceTarget;
+    address payable swapTarget;
+    bytes swapCallData;
+    uint256 deadline;
+}
+
+/**
+ * @title AlterateTokenCollectModule
+ * @author Lens Protocol & WATCHPUG
+ *
+ * @notice extend LimitedFeeCollect to take a new input "outputCurrency", and use 0xProject to take all collect proceeds and swap into outputCurrency.
+ */
+contract AlterateTokenCollectModule is
+    ICollectModule,
+    SwapDelegatorFactory,
+    FeeModuleBase,
+    FollowValidationModuleBase
+{
+    using SafeERC20 for IERC20;
+
+    mapping(uint256 => mapping(uint256 => ProfilePublicationData))
+        internal _dataByPublicationByProfile;
+
+    mapping(uint256 => address) public swapDelegatorByProfile;
+
+    constructor(address hub, address moduleGlobals) FeeModuleBase(moduleGlobals) ModuleBase(hub) {}
+
+    /**
+     * @notice This collect module levies a fee on collects and supports referrals. Thus, we need to decode data.
+     *
+     * @param data The arbitrary data parameter, decoded into:
+     *      uint256 collectLimit: The maximum amount of collects.
+     *      uint256 amount: The currency total amount to levy.
+     *      address currency: The currency address, must be internally whitelisted.
+     *      address recipient: The custom recipient address to direct earnings to.
+     *      uint16 referralFee: The referral fee to set.
+     *
+     * @return An abi encoded bytes parameter, which is the same as the passed data parameter.
+     */
+    function initializePublicationCollectModule(
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) external override onlyHub returns (bytes memory) {
+        (
+            uint256 collectLimit,
+            uint256 amount,
+            address currency,
+            address outputCurrency,
+            address recipient,
+            uint16 referralFee
+        ) = abi.decode(data, (uint256, uint256, address, address, address, uint16));
+        if (
+            collectLimit == 0 ||
+            !_currencyWhitelisted(currency) ||
+            recipient == address(0) ||
+            referralFee > BPS_MAX ||
+            amount < BPS_MAX
+        ) revert Errors.InitParamsInvalid();
+
+        _dataByPublicationByProfile[profileId][pubId].collectLimit = collectLimit;
+        _dataByPublicationByProfile[profileId][pubId].amount = amount;
+        _dataByPublicationByProfile[profileId][pubId].currency = currency;
+        _dataByPublicationByProfile[profileId][pubId].outputCurrency = outputCurrency;
+        _dataByPublicationByProfile[profileId][pubId].recipient = recipient;
+        _dataByPublicationByProfile[profileId][pubId].referralFee = referralFee;
+
+        address _delegation = swapDelegatorByProfile[profileId];
+        if (_delegation == address(0)) {
+            _delegation = _createDelegation(_computeSalt(profileId), recipient);
+            swapDelegatorByProfile[profileId] = _delegation;
+        } else {
+            TokenSwapDelegation(_delegation).initialize(recipient);
+        }
+
+        return data;
+    }
+
+    /**
+     * @dev Processes a collect by:
+     *  1. Ensuring the collector is a follower
+     *  2. Ensuring the collect does not pass the collect limit
+     *  3. Charging a fee
+     */
+    function processCollect(
+        uint256 referrerProfileId,
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) external override onlyHub {
+        _checkFollowValidity(profileId, collector);
+
+        if (
+            _dataByPublicationByProfile[profileId][pubId].currentCollects >=
+            _dataByPublicationByProfile[profileId][pubId].collectLimit
+        ) {
+            revert Errors.MintLimitExceeded();
+        } else {
+            _dataByPublicationByProfile[profileId][pubId].currentCollects++;
+            if (referrerProfileId == profileId) {
+                _processCollect(collector, profileId, pubId, data);
+            } else {
+                _processCollectWithReferral(referrerProfileId, collector, profileId, pubId, data);
+            }
+        }
+    }
+
+    function swapByQuote(uint256 profileId, SwapByQuoteData calldata swapByQuoteData) external {
+        if (msg.sender != IERC721(HUB).ownerOf(profileId)) revert Errors.NotProfileOwner();
+
+        address _delegation = swapDelegatorByProfile[profileId];
+
+        if (_delegation != address(0)) {
+            TokenSwapDelegation(_delegation).swapByQuote(
+                swapByQuoteData.sellTokenAddress,
+                swapByQuoteData.amountToSell,
+                swapByQuoteData.buyTokenAddress,
+                swapByQuoteData.minimumAmountReceived,
+                swapByQuoteData.allowanceTarget,
+                swapByQuoteData.swapTarget,
+                swapByQuoteData.swapCallData,
+                swapByQuoteData.deadline
+            );
+        }
+    }
+
+    /**
+     * @notice Returns the publication data for a given publication, or an empty struct if that publication was not
+     * initialized with this module.
+     *
+     * @param profileId The token ID of the profile mapped to the publication to query.
+     * @param pubId The publication ID of the publication to query.
+     *
+     * @return The ProfilePublicationData struct mapped to that publication.
+     */
+    function getPublicationData(uint256 profileId, uint256 pubId)
+        external
+        view
+        returns (ProfilePublicationData memory)
+    {
+        return _dataByPublicationByProfile[profileId][pubId];
+    }
+
+    function _processCollect(
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) internal {
+        uint256 amount = _dataByPublicationByProfile[profileId][pubId].amount;
+        address currency = _dataByPublicationByProfile[profileId][pubId].currency;
+        _validateDataIsExpected(data, currency, amount);
+
+        (address treasury, uint16 treasuryFee) = _treasuryData();
+        address recipient = swapDelegatorByProfile[profileId];
+        uint256 treasuryAmount = (amount * treasuryFee) / BPS_MAX;
+        uint256 adjustedAmount = amount - treasuryAmount;
+
+        IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
+        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+    }
+
+    function _processCollectWithReferral(
+        uint256 referrerProfileId,
+        address collector,
+        uint256 profileId,
+        uint256 pubId,
+        bytes calldata data
+    ) internal {
+        uint256 amount = _dataByPublicationByProfile[profileId][pubId].amount;
+        address currency = _dataByPublicationByProfile[profileId][pubId].currency;
+        _validateDataIsExpected(data, currency, amount);
+
+        uint256 referralFee = _dataByPublicationByProfile[profileId][pubId].referralFee;
+        address treasury;
+        uint256 treasuryAmount;
+
+        // Avoids stack too deep
+        {
+            uint16 treasuryFee;
+            (treasury, treasuryFee) = _treasuryData();
+            treasuryAmount = (amount * treasuryFee) / BPS_MAX;
+        }
+
+        uint256 adjustedAmount = amount - treasuryAmount;
+
+        if (referralFee != 0) {
+            // The reason we levy the referral fee on the adjusted amount is so that referral fees
+            // don't bypass the treasury fee, in essence referrals pay their fair share to the treasury.
+            uint256 referralAmount = (adjustedAmount * referralFee) / BPS_MAX;
+            adjustedAmount = adjustedAmount - referralAmount;
+
+            address referralRecipient = IERC721(HUB).ownerOf(referrerProfileId);
+
+            IERC20(currency).safeTransferFrom(collector, referralRecipient, referralAmount);
+        }
+        address recipient = swapDelegatorByProfile[profileId];
+
+        IERC20(currency).safeTransferFrom(collector, recipient, adjustedAmount);
+        IERC20(currency).safeTransferFrom(collector, treasury, treasuryAmount);
+    }
+}

--- a/contracts/misc/SwapDelegatorFactory.sol
+++ b/contracts/misc/SwapDelegatorFactory.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: GPL-3.0
+
+pragma solidity 0.8.10;
+
+import '@openzeppelin/contracts/proxy/Clones.sol';
+
+import './TokenSwapDelegation.sol';
+
+/// @title The SwapDelegatorFactory allows users to create TokenSwapDelegation very cheaply.
+contract SwapDelegatorFactory {
+    using Clones for address;
+
+    /// @notice The instance to which all proxies will point.
+    TokenSwapDelegation public delegationInstance;
+
+    /// @notice Contract constructor.
+    constructor() {
+        delegationInstance = new TokenSwapDelegation();
+        delegationInstance.initialize(address(0));
+    }
+
+    /**
+     * @notice Creates a clone of the delegation.
+     * @param _salt Random number used to deterministically deploy the clone
+     * @param _recipient The custom recipient address to direct earnings to.
+     * @return The newly created delegation
+     */
+    function _createDelegation(bytes32 _salt, address _recipient) internal returns (address) {
+        TokenSwapDelegation _delegation = TokenSwapDelegation(address(delegationInstance).cloneDeterministic(_salt));
+        _delegation.initialize(_recipient);
+        return address(_delegation);
+    }
+
+    /**
+     * @notice Computes salt used to deterministically deploy a clone.
+     * @param _profileId profileId of the delegator
+     * @return Salt used to deterministically deploy a clone.
+     */
+    function _computeSalt(uint256 _profileId) internal pure returns (bytes32) {
+        return keccak256(abi.encodePacked(_profileId));
+    }
+}

--- a/contracts/misc/TokenSwapDelegation.sol
+++ b/contracts/misc/TokenSwapDelegation.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity 0.8.10;
+
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
+
+contract TokenSwapDelegation {
+    using SafeERC20 for IERC20;
+
+    /// @notice Contract owner.
+    address private _owner;
+
+    /// @notice The custom recipient address to direct earnings to.
+    address public recipient;
+
+    event BoughtTokens(address sellToken, address buyToken, uint256 boughtAmount);
+
+    /**
+     * @notice Initializes the delegation.
+     * @param _recipient The custom recipient address to direct earnings to.
+     */
+    function initialize(address _recipient) public {
+        require(_owner == address(0) || msg.sender == _owner, 'already-init');
+        _owner = msg.sender;
+        recipient = _recipient;
+    }
+
+    /// @notice Swap by filling a 0x quote.
+    /// @dev Execute a swap by filling a 0x quote, as provided by the 0x API.
+    ///      Charges a governable swap fee that comes out of the bought asset,
+    ///      be it token or ETH. Unfortunately, the fee is also charged on any
+    ///      refunded ETH from 0x protocol fees due to an implementation oddity.
+    ///      This behavior shouldn't impact most users.
+    ///
+    ///      Learn more about the 0x API and quotes at https://0x.org/docs/api
+    /// @param sellTokenAddress The contract address of the token to be sold,
+    ///        as returned by the 0x `/swap/v1/quote` API endpoint. If selling
+    ///        unwrapped ETH included via msg.value, this should be address(0)
+    /// @param amountToSell Amount of token to sell, with the same precision as
+    ///        sellTokenAddress. This information is also encoded in swapCallData.
+    ///        If selling unwrapped ETH via msg.value, this should be 0.
+    /// @param buyTokenAddress The contract address of the token to be bought,
+    ///        as returned by the 0x `/swap/v1/quote` API endpoint. To buy
+    ///        unwrapped ETH, use `0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee`
+    /// @param minimumAmountReceived The minimum amount expected to be received
+    ///        from filling the quote, before the swap fee is deducted, in
+    ///        buyTokenAddress. Reverts if not met
+    /// @param allowanceTarget Contract address that needs to be approved for
+    ///        sellTokenAddress, as returned by the 0x `/swap/v1/quote` API
+    ///        endpoint. Should be address(0) for purchases uses unwrapped ETH
+    /// @param swapTarget Contract to fill the 0x quote, as returned by the 0x
+    ///        `/swap/v1/quote` API endpoint
+    /// @param swapCallData Data encoding the 0x quote, as returned by the 0x
+    ///        `/swap/v1/quote` API endpoint
+    /// @param deadline Timestamp after which the swap will be reverted.
+    function swapByQuote(
+        address sellTokenAddress,
+        uint256 amountToSell,
+        address buyTokenAddress,
+        uint256 minimumAmountReceived,
+        address allowanceTarget,
+        address payable swapTarget,
+        bytes calldata swapCallData,
+        uint256 deadline
+    ) external payable onlyOwner {
+        require(block.timestamp <= deadline, '!deadline');
+
+        // Track our balance of the outputCurrency to determine how much we've bought.
+        uint256 boughtAmount = IERC20(buyTokenAddress).balanceOf(address(this));
+
+        IERC20(sellTokenAddress).safeIncreaseAllowance(allowanceTarget, amountToSell);
+
+        (bool success,) = swapTarget.call{value: msg.value}(swapCallData);
+        require(success, 'SWAP_CALL_FAILED');
+
+        boughtAmount = IERC20(buyTokenAddress).balanceOf(address(this)) - boughtAmount;
+        IERC20(buyTokenAddress).safeTransfer(recipient, boughtAmount);
+
+        // return any refunded ETH
+        if (address(this).balance > 0) {
+            payable(recipient).transfer(address(this).balance);
+        }
+
+        emit BoughtTokens(sellTokenAddress, buyTokenAddress, boughtAmount);
+    }
+
+
+    /// @notice Modifier to only allow the contract owner to call a function
+    modifier onlyOwner() {
+        require(msg.sender == _owner, 'only-owner');
+        _;
+    }
+}

--- a/contracts/mocks/CurrencyTwo.sol
+++ b/contracts/mocks/CurrencyTwo.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+
+pragma solidity 0.8.10;
+
+import {ERC20} from '@openzeppelin/contracts/token/ERC20/ERC20.sol';
+
+contract CurrencyTwo is ERC20('CurrencyTwo', 'TWO') {
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+}

--- a/contracts/mocks/MockZeroXExchange.sol
+++ b/contracts/mocks/MockZeroXExchange.sol
@@ -1,0 +1,15 @@
+pragma solidity 0.8.10;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+contract MockZeroXExchange {
+
+    function sellToUniswap(address[] calldata tokens, uint256 tokenAmount) external payable {
+        require(tokens.length > 1, "tokens");
+        IERC20 tokenToSell = IERC20(tokens[0]);
+        IERC20 tokenToBuy = IERC20(tokens[1]);
+        tokenToSell.transferFrom(msg.sender, address(this), tokenAmount);
+        tokenToBuy.transfer(msg.sender, tokenAmount * 2);
+    }
+
+}

--- a/test/__setup.spec.ts
+++ b/test/__setup.spec.ts
@@ -11,6 +11,8 @@ import {
   CollectNFT__factory,
   Currency,
   Currency__factory,
+  CurrencyTwo,
+  CurrencyTwo__factory,
   EmptyCollectModule,
   EmptyCollectModule__factory,
   Events,
@@ -29,12 +31,16 @@ import {
   LensHub__factory,
   LimitedFeeCollectModule,
   LimitedFeeCollectModule__factory,
+  AlterateTokenCollectModule,
+  AlterateTokenCollectModule__factory,
   LimitedTimedFeeCollectModule,
   LimitedTimedFeeCollectModule__factory,
   MockFollowModule,
   MockFollowModule__factory,
   MockReferenceModule,
   MockReferenceModule__factory,
+  MockZeroXExchange,
+  MockZeroXExchange__factory,
   ModuleGlobals,
   ModuleGlobals__factory,
   PublishingLogic__factory,
@@ -88,11 +94,13 @@ export let testWallet: Wallet;
 export let lensHubImpl: LensHub;
 export let lensHub: LensHub;
 export let currency: Currency;
+export let currencyTwo: CurrencyTwo;
 export let abiCoder: AbiCoder;
 export let mockModuleData: BytesLike;
 export let hubLibs: LensHubLibraryAddresses;
 export let eventsLib: Events;
 export let moduleGlobals: ModuleGlobals;
+export let mockZeroXExchange: MockZeroXExchange;
 export let helper: Helper;
 
 /* Modules */
@@ -103,6 +111,7 @@ export let timedFeeCollectModule: TimedFeeCollectModule;
 export let emptyCollectModule: EmptyCollectModule;
 export let revertCollectModule: RevertCollectModule;
 export let limitedFeeCollectModule: LimitedFeeCollectModule;
+export let alterateTokenCollectModule: AlterateTokenCollectModule;
 export let limitedTimedFeeCollectModule: LimitedTimedFeeCollectModule;
 
 // Follow
@@ -185,8 +194,11 @@ before(async function () {
   // Connect the hub proxy to the LensHub factory and the user for ease of use.
   lensHub = LensHub__factory.connect(proxy.address, user);
 
+  mockZeroXExchange = await new MockZeroXExchange__factory(deployer).deploy();
+
   // Currency
   currency = await new Currency__factory(deployer).deploy();
+  currencyTwo = await new CurrencyTwo__factory(deployer).deploy();
 
   // Modules
   emptyCollectModule = await new EmptyCollectModule__factory(deployer).deploy(lensHub.address);
@@ -200,6 +212,10 @@ before(async function () {
     moduleGlobals.address
   );
   limitedFeeCollectModule = await new LimitedFeeCollectModule__factory(deployer).deploy(
+    lensHub.address,
+    moduleGlobals.address
+  );
+  alterateTokenCollectModule = await new AlterateTokenCollectModule__factory(deployer).deploy(
     lensHub.address,
     moduleGlobals.address
   );

--- a/test/modules/collect/alterate-token-collect-module.spec.ts
+++ b/test/modules/collect/alterate-token-collect-module.spec.ts
@@ -1,0 +1,806 @@
+import { BigNumber } from '@ethersproject/bignumber';
+import { parseEther } from '@ethersproject/units';
+import '@nomiclabs/hardhat-ethers';
+import { expect } from 'chai';
+import { MAX_UINT256, ZERO_ADDRESS } from '../../helpers/constants';
+import { ERRORS } from '../../helpers/errors';
+import { getTimestamp, matchEvent, waitForTx } from '../../helpers/utils';
+import {
+  abiCoder,
+  BPS_MAX,
+  currency,
+  currencyTwo,
+  FIRST_PROFILE_ID,
+  governance,
+  lensHub,
+  alterateTokenCollectModule,
+  makeSuiteCleanRoom,
+  MOCK_FOLLOW_NFT_URI,
+  MOCK_PROFILE_HANDLE,
+  MOCK_PROFILE_URI,
+  MOCK_URI,
+  moduleGlobals,
+  REFERRAL_FEE_BPS,
+  treasuryAddress,
+  TREASURY_FEE_BPS,
+  userAddress,
+  userTwo,
+  userTwoAddress,
+  mockZeroXExchange,
+  user,
+} from '../../__setup.spec';
+
+makeSuiteCleanRoom('Alterate Token Collect Module', function () {
+  const DEFAULT_COLLECT_PRICE = parseEther('10');
+  const DEFAULT_COLLECT_LIMIT = 3;
+
+  beforeEach(async function () {
+    await expect(
+      lensHub.createProfile({
+        to: userAddress,
+        handle: MOCK_PROFILE_HANDLE,
+        imageURI: MOCK_PROFILE_URI,
+        followModule: ZERO_ADDRESS,
+        followModuleData: [],
+        followNFTURI: MOCK_FOLLOW_NFT_URI,
+      })
+    ).to.not.be.reverted;
+    await expect(
+      lensHub.connect(governance).whitelistCollectModule(alterateTokenCollectModule.address, true)
+    ).to.not.be.reverted;
+    await expect(
+      moduleGlobals.connect(governance).whitelistCurrency(currency.address, true)
+    ).to.not.be.reverted;
+  });
+
+  context('Negatives', function () {
+    context('Publication Creation', function () {
+      it('user should fail to post with limited fee collect module using zero collect limit', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+          [
+            0,
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            currencyTwo.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: alterateTokenCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with limited fee collect module using unwhitelisted currency', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            DEFAULT_COLLECT_PRICE,
+            userTwoAddress,
+            currencyTwo.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: alterateTokenCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with limited fee collect module using zero recipient', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            currencyTwo.address,
+            ZERO_ADDRESS,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: alterateTokenCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with limited fee collect module using referral fee greater than max BPS', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            currencyTwo.address,
+            userAddress,
+            10001,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: alterateTokenCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+
+      it('user should fail to post with limited fee collect module using amount lower than max BPS', async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            9999,
+            currency.address,
+            currencyTwo.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: alterateTokenCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.be.revertedWith(ERRORS.INIT_PARAMS_INVALID);
+      });
+    });
+
+    context('Collecting', function () {
+      beforeEach(async function () {
+        const collectModuleData = abiCoder.encode(
+          ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+          [
+            DEFAULT_COLLECT_LIMIT,
+            DEFAULT_COLLECT_PRICE,
+            currency.address,
+            currencyTwo.address,
+            userAddress,
+            REFERRAL_FEE_BPS,
+          ]
+        );
+        await expect(
+          lensHub.post({
+            profileId: FIRST_PROFILE_ID,
+            contentURI: MOCK_URI,
+            collectModule: alterateTokenCollectModule.address,
+            collectModuleData: collectModuleData,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+      });
+
+      it('UserTwo should fail to collect without following', async function () {
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.FOLLOW_INVALID);
+      });
+
+      it('UserTwo should fail to collect passing a different expected price in data', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE.div(2)]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should fail to collect passing a different expected currency in data', async function () {
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(['address', 'uint256'], [userAddress, DEFAULT_COLLECT_PRICE]);
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.MODULE_DATA_MISMATCH);
+      });
+
+      it('UserTwo should fail to collect without first approving module with currency', async function () {
+        await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(
+          lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)
+        ).to.be.revertedWith(ERRORS.ERC20_TRANSFER_EXCEEDS_ALLOWANCE);
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror without following the original profile', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE]
+        );
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.FOLLOW_INVALID
+        );
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror passing a different expected price in data', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        const data = abiCoder.encode(
+          ['address', 'uint256'],
+          [currency.address, DEFAULT_COLLECT_PRICE.div(2)]
+        );
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.MODULE_DATA_MISMATCH
+        );
+      });
+
+      it('UserTwo should mirror the original post, fail to collect from their mirror passing a different expected currency in data', async function () {
+        const secondProfileId = FIRST_PROFILE_ID + 1;
+        await expect(
+          lensHub.connect(userTwo).createProfile({
+            to: userTwoAddress,
+            handle: 'usertwo',
+            imageURI: MOCK_PROFILE_URI,
+            followModule: ZERO_ADDRESS,
+            followModuleData: [],
+            followNFTURI: MOCK_FOLLOW_NFT_URI,
+          })
+        ).to.not.be.reverted;
+        await expect(
+          lensHub.connect(userTwo).mirror({
+            profileId: secondProfileId,
+            profileIdPointed: FIRST_PROFILE_ID,
+            pubIdPointed: 1,
+            referenceModule: ZERO_ADDRESS,
+            referenceModuleData: [],
+          })
+        ).to.not.be.reverted;
+
+        await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+        const data = abiCoder.encode(['address', 'uint256'], [userAddress, DEFAULT_COLLECT_PRICE]);
+        await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+          ERRORS.MODULE_DATA_MISMATCH
+        );
+      });
+    });
+  });
+
+  context('Scenarios', function () {
+    it('User should post with limited fee collect module as the collect module and data, correct events should be emitted', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          currencyTwo.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      const tx = lensHub.post({
+        profileId: FIRST_PROFILE_ID,
+        contentURI: MOCK_URI,
+        collectModule: alterateTokenCollectModule.address,
+        collectModuleData: collectModuleData,
+        referenceModule: ZERO_ADDRESS,
+        referenceModuleData: [],
+      });
+
+      const receipt = await waitForTx(tx);
+
+      expect(receipt.logs.length).to.eq(1);
+      matchEvent(receipt, 'PostCreated', [
+        FIRST_PROFILE_ID,
+        1,
+        MOCK_URI,
+        alterateTokenCollectModule.address,
+        collectModuleData,
+        ZERO_ADDRESS,
+        [],
+        await getTimestamp(),
+      ]);
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, fetched publication data should be accurate', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          currencyTwo.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: alterateTokenCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      const fetchedData = await alterateTokenCollectModule.getPublicationData(FIRST_PROFILE_ID, 1);
+      expect(fetchedData.collectLimit).to.eq(DEFAULT_COLLECT_LIMIT);
+      expect(fetchedData.amount).to.eq(DEFAULT_COLLECT_PRICE);
+      expect(fetchedData.recipient).to.eq(userAddress);
+      expect(fetchedData.currency).to.eq(currency.address);
+      expect(fetchedData.referralFee).to.eq(REFERRAL_FEE_BPS);
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, user two follows, then collects and pays fee, fee distribution is valid', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          currencyTwo.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: alterateTokenCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(alterateTokenCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+      );
+
+      const swapDelegator = await alterateTokenCollectModule.swapDelegatorByProfile(
+        FIRST_PROFILE_ID
+      );
+
+      expect(await currency.balanceOf(swapDelegator)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, user two follows, then collects and pays fee, fee distribution is valid, User can swapByQuote get outputCurrency', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          currencyTwo.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: alterateTokenCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(alterateTokenCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+      );
+
+      const swapDelegator = await alterateTokenCollectModule.swapDelegatorByProfile(
+        FIRST_PROFILE_ID
+      );
+
+      await expect(currencyTwo.mint(mockZeroXExchange.address, MAX_UINT256)).to.not.be.reverted;
+
+      expect(await currency.balanceOf(swapDelegator)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+
+      const swapCallData = mockZeroXExchange.interface.encodeFunctionData('sellToUniswap', [
+        [currency.address, currencyTwo.address],
+        expectedRecipientAmount,
+      ]);
+
+      await expect(
+        alterateTokenCollectModule.connect(user).swapByQuote(FIRST_PROFILE_ID, {
+          sellTokenAddress: currency.address,
+          amountToSell: expectedRecipientAmount,
+          buyTokenAddress: currencyTwo.address,
+          minimumAmountReceived: expectedRecipientAmount,
+          allowanceTarget: mockZeroXExchange.address,
+          swapTarget: mockZeroXExchange.address,
+          swapCallData: swapCallData,
+          deadline: 10000000000000,
+        })
+      ).to.not.be.reverted;
+
+      expect(await currencyTwo.balanceOf(userAddress)).to.eq(expectedRecipientAmount.mul(2));
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, user two follows, then collects twice, fee distribution is valid', async function () {
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          currencyTwo.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: alterateTokenCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(alterateTokenCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(BigNumber.from(DEFAULT_COLLECT_PRICE).mul(2))
+      );
+
+      const swapDelegator = await alterateTokenCollectModule.swapDelegatorByProfile(
+        FIRST_PROFILE_ID
+      );
+
+      expect(await currency.balanceOf(swapDelegator)).to.eq(expectedRecipientAmount.mul(2));
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount.mul(2));
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, user two mirrors, follows, then collects from their mirror and pays fee, fee distribution is valid', async function () {
+      const secondProfileId = FIRST_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          currencyTwo.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: alterateTokenCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: secondProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(alterateTokenCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+
+      const swapDelegator = await alterateTokenCollectModule.swapDelegatorByProfile(
+        FIRST_PROFILE_ID
+      );
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedReferralAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .sub(expectedTreasuryAmount)
+        .mul(REFERRAL_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedReferrerAmount = BigNumber.from(MAX_UINT256)
+        .sub(DEFAULT_COLLECT_PRICE)
+        .add(expectedReferralAmount);
+      const expectedRecipientAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .sub(expectedTreasuryAmount)
+        .sub(expectedReferralAmount);
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(expectedReferrerAmount);
+      expect(await currency.balanceOf(swapDelegator)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, with no referral fee, user two mirrors, follows, then collects from their mirror and pays fee, fee distribution is valid', async function () {
+      const secondProfileId = FIRST_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          currencyTwo.address,
+          userAddress,
+          0,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: alterateTokenCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: secondProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(alterateTokenCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+
+      const expectedTreasuryAmount = BigNumber.from(DEFAULT_COLLECT_PRICE)
+        .mul(TREASURY_FEE_BPS)
+        .div(BPS_MAX);
+      const expectedRecipientAmount =
+        BigNumber.from(DEFAULT_COLLECT_PRICE).sub(expectedTreasuryAmount);
+
+      const swapDelegator = await alterateTokenCollectModule.swapDelegatorByProfile(
+        FIRST_PROFILE_ID
+      );
+
+      expect(await currency.balanceOf(userTwoAddress)).to.eq(
+        BigNumber.from(MAX_UINT256).sub(DEFAULT_COLLECT_PRICE)
+      );
+      expect(await currency.balanceOf(swapDelegator)).to.eq(expectedRecipientAmount);
+      expect(await currency.balanceOf(treasuryAddress)).to.eq(expectedTreasuryAmount);
+    });
+
+    it('User should post with limited fee collect module as the collect module and data, user two mirrors, follows, then collects once from the original, twice from the mirror, and fails to collect a third time from either the mirror or the original', async function () {
+      const secondProfileId = FIRST_PROFILE_ID + 1;
+      const collectModuleData = abiCoder.encode(
+        ['uint256', 'uint256', 'address', 'address', 'address', 'uint16'],
+        [
+          DEFAULT_COLLECT_LIMIT,
+          DEFAULT_COLLECT_PRICE,
+          currency.address,
+          currencyTwo.address,
+          userAddress,
+          REFERRAL_FEE_BPS,
+        ]
+      );
+      await expect(
+        lensHub.post({
+          profileId: FIRST_PROFILE_ID,
+          contentURI: MOCK_URI,
+          collectModule: alterateTokenCollectModule.address,
+          collectModuleData: collectModuleData,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(
+        lensHub.connect(userTwo).createProfile({
+          to: userTwoAddress,
+          handle: 'usertwo',
+          imageURI: MOCK_PROFILE_URI,
+          followModule: ZERO_ADDRESS,
+          followModuleData: [],
+          followNFTURI: MOCK_FOLLOW_NFT_URI,
+        })
+      ).to.not.be.reverted;
+      await expect(
+        lensHub.connect(userTwo).mirror({
+          profileId: secondProfileId,
+          profileIdPointed: FIRST_PROFILE_ID,
+          pubIdPointed: 1,
+          referenceModule: ZERO_ADDRESS,
+          referenceModuleData: [],
+        })
+      ).to.not.be.reverted;
+
+      await expect(currency.mint(userTwoAddress, MAX_UINT256)).to.not.be.reverted;
+      await expect(
+        currency.connect(userTwo).approve(alterateTokenCollectModule.address, MAX_UINT256)
+      ).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).follow([FIRST_PROFILE_ID], [[]])).to.not.be.reverted;
+      const data = abiCoder.encode(
+        ['address', 'uint256'],
+        [currency.address, DEFAULT_COLLECT_PRICE]
+      );
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.not.be.reverted;
+
+      await expect(lensHub.connect(userTwo).collect(FIRST_PROFILE_ID, 1, data)).to.be.revertedWith(
+        ERRORS.MINT_LIMIT_EXCEEDED
+      );
+      await expect(lensHub.connect(userTwo).collect(secondProfileId, 1, data)).to.be.revertedWith(
+        ERRORS.MINT_LIMIT_EXCEEDED
+      );
+    });
+  });
+});


### PR DESCRIPTION
Extend LimitedFeeCollect to take a new input "outputCurrency", and use 0xProject (or other aggregator) to take all collect proceeds and swap into outputCurrency.

Since the optimal path must be calculated off-chain. the swap shall be triggered by the owner.

And 0x requires kind of arbitrary code execution to fulfill the swap, we introduced a `TokenSwapDelegation` dedicated to each user for safety.