### PR TITLE
Added tool-versions to allow local development with asdf

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+nodejs 16.14.1
+solidity 0.8.7


### PR DESCRIPTION
Added spec for Solidity and Nodejs versions (matching the ones in the `Dockerfile`) to allow development using a local stack with [asdf](https://github.com/asdf-vm/asdf), as an alternative for developing over Docker.