### PR TITLE
Fix node_modules being omitted during cp

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-[ ! -d "/src/node_modules" ] && cp /node_modules /src/node_modules; bash
+[ ! -d "/src/node_modules" ] && cp -r /node_modules /src/node_modules; bash


### PR DESCRIPTION
Add recursive copy for `node_modules` folder in entrypoint.sh to avoid folder omitting.