### PR TITLE
Fix typo in FollowerOnlyReferenceModule.sol docs

### DIFF
--- a/contracts/core/modules/reference/FollowerOnlyReferenceModule.sol
+++ b/contracts/core/modules/reference/FollowerOnlyReferenceModule.sol
@@ -44,7 +44,7 @@ contract FollowerOnlyReferenceModule is FollowValidationModuleBase, IReferenceMo
     }
 
     /**
-     * @notice Validates that the commenting profile's owner is a follower.
+     * @notice Validates that the mirroring profile's owner is a follower.
      *
      * NOTE: We don't need to care what the pointed publication is in this context.
      */


### PR DESCRIPTION
   /**
     * @notice Validates that the c̶o̶m̶m̶e̶n̶t̶i̶n̶g̶ mirroring profile's owner is a follower.
     *
     * NOTE: We don't need to care what the pointed publication is in this context.
     */
    function processMirror(