### PR TITLE
refactor: :recycle: centralize the use of environment variables

### DIFF
--- a/env.ts
+++ b/env.ts
@@ -1,0 +1,18 @@
+import { config } from 'dotenv';
+config({ path: '../.env' });
+const { env } = process;
+
+export const MNEMONIC: string = env.MNEMONIC || '';
+export const PRIVATE_KEY: string = env.PRIVATE_KEY || '';
+export const DEFENDER_API_KEY: string = env.DEFENDER_API_KEY || '';
+export const DEFENDER_SECRET_KEY: string = env.DEFENDER_SECRET_KEY || '';
+export const SKIP_LOAD: boolean = (env.SKIP_LOAD && env.SKIP_LOAD === 'true') || false;
+export const MAINNET_FORK: boolean = (env.MAINNET_FORK && env.MAINNET_FORK === 'true') || false;
+export const TRACK_GAS: boolean = (env.TRACK_GAS && env.TRACK_GAS === 'true') || false;
+export const BLOCK_EXPLORER_KEY: string = env.BLOCK_EXPLORER_KEY || '';
+export const TENDERLY_FORK_ID: string = env.TENDERLY_FORK_ID || '';
+export const KOVAN_RPC_URL: string = env.KOVAN_RPC_URL || '';
+export const ROPSTEN_RPC_URL: string = env.ROPSTEN_RPC_URL || '';
+export const MAINNET_RPC_URL: string = env.MAINNET_RPC_URL || '';
+export const MUMBAI_RPC_URL: string = env.MUMBAI_RPC_URL || '';
+export const POLYGON_RPC_URL: string = env.POLYGON_RPC_URL || '';

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,12 +1,11 @@
+import { BLOCK_EXPLORER_KEY, MAINNET_FORK, MNEMONIC, SKIP_LOAD, TRACK_GAS } from './env';
 import { HardhatUserConfig } from 'hardhat/types';
 import { accounts } from './helpers/test-wallets';
 import { eEthereumNetwork, eNetwork, ePolygonNetwork, eXDaiNetwork } from './helpers/types';
 import { HARDHATEVM_CHAINID } from './helpers/hardhat-constants';
 import { NETWORKS_RPC_URL } from './helper-hardhat-config';
-import dotenv from 'dotenv';
 import glob from 'glob';
 import path from 'path';
-dotenv.config({ path: '../.env' });
 
 import '@nomiclabs/hardhat-ethers';
 import '@nomiclabs/hardhat-etherscan';
@@ -17,7 +16,7 @@ import 'hardhat-contract-sizer';
 import 'hardhat-log-remover';
 import 'hardhat-spdx-license-identifier';
 
-if (!process.env.SKIP_LOAD) {
+if (!SKIP_LOAD) {
   glob.sync('./tasks/**/*.ts').forEach(function (file) {
     require(path.resolve(file));
   });
@@ -25,10 +24,6 @@ if (!process.env.SKIP_LOAD) {
 
 const DEFAULT_BLOCK_GAS_LIMIT = 12450000;
 const MNEMONIC_PATH = "m/44'/60'/0'/0";
-const MNEMONIC = process.env.MNEMONIC || '';
-const MAINNET_FORK = process.env.MAINNET_FORK === 'true';
-const TRACK_GAS = process.env.TRACK_GAS === 'true';
-const BLOCK_EXPLORER_KEY = process.env.BLOCK_EXPLORER_KEY || '';
 
 const getCommonNetworkConfig = (networkName: eNetwork, networkId: number) => ({
   url: NETWORKS_RPC_URL[networkName] ?? '',

--- a/helper-hardhat-config.ts
+++ b/helper-hardhat-config.ts
@@ -1,25 +1,27 @@
 import {
+  KOVAN_RPC_URL,
+  MAINNET_RPC_URL,
+  MUMBAI_RPC_URL,
+  POLYGON_RPC_URL,
+  ROPSTEN_RPC_URL,
+  TENDERLY_FORK_ID,
+} from './env';
+
+import {
   eEthereumNetwork,
   ePolygonNetwork,
   eXDaiNetwork,
   iParamsPerNetwork,
 } from './helpers/types';
 
-import dotenv from 'dotenv';
-dotenv.config({});
-
-const TENDERLY_FORK_ID = process.env.TENDERLY_FORK_ID || '';
-
-const GWEI = 1000 * 1000 * 1000;
-
 export const NETWORKS_RPC_URL: iParamsPerNetwork<string> = {
-  [eEthereumNetwork.kovan]: process.env.KOVAN_RPC_URL,
-  [eEthereumNetwork.ropsten]: process.env.ROPSTEN_RPC_URL,
-  [eEthereumNetwork.main]: process.env.MAINNET_RPC_URL,
+  [eEthereumNetwork.kovan]: KOVAN_RPC_URL,
+  [eEthereumNetwork.ropsten]: ROPSTEN_RPC_URL,
+  [eEthereumNetwork.main]: MAINNET_RPC_URL,
   [eEthereumNetwork.hardhat]: 'http://localhost:8545',
   [eEthereumNetwork.harhatevm]: 'http://localhost:8545',
   [eEthereumNetwork.tenderlyMain]: `https://rpc.tenderly.co/fork/${TENDERLY_FORK_ID}`,
-  [ePolygonNetwork.mumbai]: process.env.MUMBAI_RPC_URL,
-  [ePolygonNetwork.matic]: process.env.POLYGON_RPC_URL,
+  [ePolygonNetwork.mumbai]: MUMBAI_RPC_URL,
+  [ePolygonNetwork.matic]: POLYGON_RPC_URL,
   [eXDaiNetwork.xdai]: 'https://rpc.xdaichain.com/',
 };

--- a/helpers/wallet-helpers.ts
+++ b/helpers/wallet-helpers.ts
@@ -1,13 +1,6 @@
 import { Wallet, Signer } from 'ethers';
 import { DefenderRelaySigner, DefenderRelayProvider } from 'defender-relay-client/lib/ethers';
-import dotenv from 'dotenv';
-
-dotenv.config({ path: '../.env' });
-
-const PRIVATE_KEY = process.env.PRIVATE_KEY || '';
-const MNEMONIC = process.env.MNEMONIC || '';
-const DEFENDER_API_KEY = process.env.DEFENDER_API_KEY || '';
-const DEFENDER_SECRET_KEY = process.env.DEFENDER_SECRET_KEY || '';
+import { MNEMONIC, DEFENDER_API_KEY, DEFENDER_SECRET_KEY, PRIVATE_KEY } from '../env';
 
 export const getPrivateKeyWallet = (): Signer => new Wallet(PRIVATE_KEY);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "lens-protocol",
+  "name": "@aave/lens-protocol",
   "version": "1.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "lens-protocol",
+      "name": "@aave/lens-protocol",
       "version": "1.0.2",
       "license": "MIT",
       "dependencies": {
@@ -29,7 +29,7 @@
         "eslint-plugin-prettier": "4.0.0",
         "ethereum-waffle": "3.4.0",
         "ethers": "5.5.1",
-        "hardhat": "2.7.0",
+        "hardhat": "^2.12.2",
         "hardhat-contract-sizer": "2.1.1",
         "hardhat-gas-reporter": "1.0.6",
         "hardhat-log-remover": "2.0.2",
@@ -277,22 +277,6 @@
       "dev": true,
       "license": "Python-2.0"
     },
-    "node_modules/@eslint/eslintrc/node_modules/debug": {
-      "version": "4.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@eslint/eslintrc/node_modules/ignore": {
       "version": "4.0.6",
       "dev": true,
@@ -471,80 +455,6 @@
         "node": ">=10.0"
       }
     },
-    "node_modules/@ethereumjs/block": {
-      "version": "3.6.0",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@ethereumjs/common": "^2.6.0",
-        "@ethereumjs/tx": "^3.4.0",
-        "ethereumjs-util": "^7.1.3",
-        "merkle-patricia-tree": "^4.2.2"
-      }
-    },
-    "node_modules/@ethereumjs/block/node_modules/@ethereumjs/common": {
-      "version": "2.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.1.3"
-      }
-    },
-    "node_modules/@ethereumjs/block/node_modules/@ethereumjs/tx": {
-      "version": "3.4.0",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@ethereumjs/common": "^2.6.0",
-        "ethereumjs-util": "^7.1.3"
-      }
-    },
-    "node_modules/@ethereumjs/blockchain": {
-      "version": "5.5.1",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/common": "^2.6.0",
-        "@ethereumjs/ethash": "^1.1.0",
-        "debug": "^2.2.0",
-        "ethereumjs-util": "^7.1.3",
-        "level-mem": "^5.0.1",
-        "lru-cache": "^5.1.1",
-        "semaphore-async-await": "^1.5.1"
-      }
-    },
-    "node_modules/@ethereumjs/blockchain/node_modules/@ethereumjs/common": {
-      "version": "2.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.1.3"
-      }
-    },
-    "node_modules/@ethereumjs/blockchain/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@ethereumjs/blockchain/node_modules/lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^3.0.2"
-      }
-    },
-    "node_modules/@ethereumjs/blockchain/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@ethereumjs/common": {
       "version": "2.4.0",
       "dev": true,
@@ -581,26 +491,6 @@
       },
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@ethereumjs/ethash": {
-      "version": "1.1.0",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@ethereumjs/block": "^3.5.0",
-        "@types/levelup": "^4.3.0",
-        "buffer-xor": "^2.0.1",
-        "ethereumjs-util": "^7.1.1",
-        "miller-rabin": "^4.0.0"
-      }
-    },
-    "node_modules/@ethereumjs/ethash/node_modules/buffer-xor": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.1"
       }
     },
     "node_modules/@ethereumjs/tx": {
@@ -640,56 +530,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@ethereumjs/vm": {
-      "version": "5.6.0",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/blockchain": "^5.5.0",
-        "@ethereumjs/common": "^2.6.0",
-        "@ethereumjs/tx": "^3.4.0",
-        "async-eventemitter": "^0.2.4",
-        "core-js-pure": "^3.0.1",
-        "debug": "^2.2.0",
-        "ethereumjs-util": "^7.1.3",
-        "functional-red-black-tree": "^1.0.1",
-        "mcl-wasm": "^0.7.1",
-        "merkle-patricia-tree": "^4.2.2",
-        "rustbn.js": "~0.2.0"
-      }
-    },
-    "node_modules/@ethereumjs/vm/node_modules/@ethereumjs/common": {
-      "version": "2.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "ethereumjs-util": "^7.1.3"
-      }
-    },
-    "node_modules/@ethereumjs/vm/node_modules/@ethereumjs/tx": {
-      "version": "3.4.0",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@ethereumjs/common": "^2.6.0",
-        "ethereumjs-util": "^7.1.3"
-      }
-    },
-    "node_modules/@ethereumjs/vm/node_modules/debug": {
-      "version": "2.6.9",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.0.0"
-      }
-    },
-    "node_modules/@ethereumjs/vm/node_modules/ms": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/@ethersproject/abi": {
       "version": "5.3.1",
@@ -3772,6 +3612,46 @@
       "dev": true,
       "license": "BSD-3-Clause"
     },
+    "node_modules/@metamask/eth-sig-util": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
+      "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
+      "dev": true,
+      "dependencies": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^6.2.1",
+        "ethjs-util": "^0.1.6",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@noble/secp256k1": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
+      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.4",
       "dev": true,
@@ -3802,6 +3682,379 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-block": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-4.0.0.tgz",
+      "integrity": "sha512-bk8uP8VuexLgyIZAHExH1QEovqx0Lzhc9Ntm63nCRKLHXIZkobaFaeCVwTESV7YkPKUk7NiK11s8ryed4CS9yA==",
+      "dev": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-blockchain": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-6.0.0.tgz",
+      "integrity": "sha512-pLFEoea6MWd81QQYSReLlLfH7N9v7lH66JC/NMPN848ySPPQA5renWnE7wPByfQFzNrPBuDDRFFULMDmj1C0xw==",
+      "dev": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-block": "^4.0.0",
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-ethash": "^2.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "abstract-level": "^1.0.3",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "level": "^8.0.0",
+        "lru-cache": "^5.1.1",
+        "memory-level": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-blockchain/node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-common": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-3.0.0.tgz",
+      "integrity": "sha512-WS7qSshQfxoZOpHG/XqlHEGRG1zmyjYrvmATvc4c62+gZXgre1ymYP8ZNgx/3FyZY0TWe9OjFlKOfLqmgOeYwA==",
+      "dev": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "crc-32": "^1.2.0"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-ethash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-2.0.0.tgz",
+      "integrity": "sha512-WpDvnRncfDUuXdsAXlI4lXbqUDOA+adYRQaEezIkxqDkc+LDyYDbd/xairmY98GnQzo1zIqsIL6GB5MoMSJDew==",
+      "dev": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-block": "^4.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "abstract-level": "^1.0.3",
+        "bigint-crypto-utils": "^3.0.23",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-evm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.0.0.tgz",
+      "integrity": "sha512-hVS6qRo3V1PLKCO210UfcEQHvlG7GqR8iFzp0yyjTg2TmJQizcChKgWo8KFsdMw6AyoLgLhHGHw4HdlP8a4i+Q==",
+      "dev": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@types/async-eventemitter": "^0.2.1",
+        "async-eventemitter": "^0.2.4",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "mcl-wasm": "^0.7.1",
+        "rustbn.js": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-rlp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.0.tgz",
+      "integrity": "sha512-GaSOGk5QbUk4eBP5qFbpXoZoZUj/NrW7MRa0tKY4Ew4c2HAS0GXArEMAamtFrkazp0BO4K5p2ZCG3b2FmbShmw==",
+      "dev": true,
+      "bin": {
+        "rlp": "bin/rlp"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-statemanager": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-1.0.0.tgz",
+      "integrity": "sha512-jCtqFjcd2QejtuAMjQzbil/4NHf5aAWxUc+CvS0JclQpl+7M0bxMofR2AJdtz+P3u0ke2euhYREDiE7iSO31vQ==",
+      "dev": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "functional-red-black-tree": "^1.0.1"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-trie": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-5.0.0.tgz",
+      "integrity": "sha512-LIj5XdE+s+t6WSuq/ttegJzZ1vliwg6wlb+Y9f4RlBpuK35B9K02bO7xU+E6Rgg9RGptkWd6TVLdedTI4eNc2A==",
+      "dev": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "ethereum-cryptography": "0.1.3",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-tx": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-4.0.0.tgz",
+      "integrity": "sha512-Gg3Lir2lNUck43Kp/3x6TfBNwcWC9Z1wYue9Nz3v4xjdcv6oDW9QSMJxqsKw9QEGoBBZ+gqwpW7+F05/rs/g1w==",
+      "dev": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-util": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.0.tgz",
+      "integrity": "sha512-2emi0NJ/HmTG+CGY58fa+DQuAoroFeSH9gKu9O6JnwTtlzJtgfTixuoOqLEgyyzZVvwfIpRueuePb8TonL1y+A==",
+      "dev": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0-beta.2",
+        "ethereum-cryptography": "0.1.3"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/ethereumjs-vm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.0.0.tgz",
+      "integrity": "sha512-JMPxvPQ3fzD063Sg3Tp+UdwUkVxMoo1uML6KSzFhMH3hoQi/LMuXBoEHAoW83/vyNS9BxEe6jm6LmT5xdeEJ6w==",
+      "dev": true,
+      "dependencies": {
+        "@nomicfoundation/ethereumjs-block": "^4.0.0",
+        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@types/async-eventemitter": "^0.2.1",
+        "async-eventemitter": "^0.2.4",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "functional-red-black-tree": "^1.0.1",
+        "mcl-wasm": "^0.7.1",
+        "rustbn.js": "~0.2.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.0.tgz",
+      "integrity": "sha512-xGWAiVCGOycvGiP/qrlf9f9eOn7fpNbyJygcB0P21a1MDuVPlKt0Srp7rvtBEutYQ48ouYnRXm33zlRnlTOPHg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12"
+      },
+      "optionalDependencies": {
+        "@nomicfoundation/solidity-analyzer-darwin-arm64": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-darwin-x64": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-freebsd-x64": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-linux-x64-musl": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.0"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-darwin-arm64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.0.tgz",
+      "integrity": "sha512-vEF3yKuuzfMHsZecHQcnkUrqm8mnTWfJeEVFHpg+cO+le96xQA4lAJYdUan8pXZohQxv1fSReQsn4QGNuBNuCw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-darwin-x64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.0.tgz",
+      "integrity": "sha512-dlHeIg0pTL4dB1l9JDwbi/JG6dHQaU1xpDK+ugYO8eJ1kxx9Dh2isEUtA4d02cQAl22cjOHTvifAk96A+ItEHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-freebsd-x64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.0.tgz",
+      "integrity": "sha512-WFCZYMv86WowDA4GiJKnebMQRt3kCcFqHeIomW6NMyqiKqhK1kIZCxSLDYsxqlx396kKLPN1713Q1S8tu68GKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-gnu": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.0.tgz",
+      "integrity": "sha512-DTw6MNQWWlCgc71Pq7CEhEqkb7fZnS7oly13pujs4cMH1sR0JzNk90Mp1zpSCsCs4oKan2ClhMlLKtNat/XRKQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-arm64-musl": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.0.tgz",
+      "integrity": "sha512-wUpUnR/3GV5Da88MhrxXh/lhb9kxh9V3Jya2NpBEhKDIRCDmtXMSqPMXHZmOR9DfCwCvG6vLFPr/+YrPCnUN0w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-gnu": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.0.tgz",
+      "integrity": "sha512-lR0AxK1x/MeKQ/3Pt923kPvwigmGX3OxeU5qNtQ9pj9iucgk4PzhbS3ruUeSpYhUxG50jN4RkIGwUMoev5lguw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-linux-x64-musl": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.0.tgz",
+      "integrity": "sha512-A1he/8gy/JeBD3FKvmI6WUJrGrI5uWJNr5Xb9WdV+DK0F8msuOqpEByLlnTdLkXMwW7nSl3awvLezOs9xBHJEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-arm64-msvc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.0.tgz",
+      "integrity": "sha512-7x5SXZ9R9H4SluJZZP8XPN+ju7Mx+XeUMWZw7ZAqkdhP5mK19I4vz3x0zIWygmfE8RT7uQ5xMap0/9NPsO+ykw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-ia32-msvc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.0.tgz",
+      "integrity": "sha512-m7w3xf+hnE774YRXu+2mGV7RiF3QJtUoiYU61FascCkQhX3QMQavh7saH/vzb2jN5D24nT/jwvaHYX/MAM9zUw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.0.tgz",
+      "integrity": "sha512-xCuybjY0sLJQnJhupiFAXaek2EqF0AP0eBjgzaalPXSNvCEN6ZYHvUzdA50ENDVeSYFXcUsYf3+FsD3XKaeptA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@nomiclabs/hardhat-ethers": {
@@ -3914,6 +4167,51 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.0.tgz",
+      "integrity": "sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.1.1",
+        "@noble/secp256k1": "~1.6.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
+      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.1.1",
+        "@scure/base": "~1.1.0"
       }
     },
     "node_modules/@sentry/core": {
@@ -4208,10 +4506,11 @@
         "node": ">= 10.0.0"
       }
     },
-    "node_modules/@types/abstract-leveldown": {
-      "version": "5.0.2",
-      "dev": true,
-      "license": "MIT"
+    "node_modules/@types/async-eventemitter": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.1.tgz",
+      "integrity": "sha512-M2P4Ng26QbAeITiH7w1d7OxtldgfAe0wobpyJzVK/XOb0cUGKU2R4pfAhqcJBXAe2ife5ZOhSv4wk7p+ffURtg==",
+      "dev": true
     },
     "node_modules/@types/bn.js": {
       "version": "4.11.6",
@@ -4255,21 +4554,6 @@
       "version": "7.0.9",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/level-errors": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/levelup": {
-      "version": "4.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/abstract-leveldown": "*",
-        "@types/level-errors": "*",
-        "@types/node": "*"
-      }
     },
     "node_modules/@types/lru-cache": {
       "version": "5.1.1",
@@ -4373,22 +4657,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/eslint-plugin/node_modules/debug": {
-      "version": "4.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@typescript-eslint/experimental-utils": {
       "version": "5.5.0",
       "dev": true,
@@ -4434,22 +4702,6 @@
       },
       "peerDependenciesMeta": {
         "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/parser/node_modules/debug": {
-      "version": "4.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
           "optional": true
         }
       }
@@ -4508,22 +4760,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/debug": {
-      "version": "4.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/is-glob": {
       "version": "4.0.3",
       "dev": true,
@@ -4572,19 +4808,46 @@
         "node": ">=6.5"
       }
     },
-    "node_modules/abstract-leveldown": {
-      "version": "6.3.0",
+    "node_modules/abstract-level": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
+      "integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
+      }
+    },
+    "node_modules/abstract-level/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/accepts": {
@@ -4656,6 +4919,19 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "dependencies": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ajv": {
@@ -4859,17 +5135,19 @@
       }
     },
     "node_modules/async": {
-      "version": "2.6.3",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
     },
     "node_modules/async-eventemitter": {
       "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "async": "^2.4.0"
       }
@@ -4973,6 +5251,27 @@
       "version": "1.1.4",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bigint-crypto-utils": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.1.7.tgz",
+      "integrity": "sha512-zpCQpIE2Oy5WIQpjC9iYZf8Uh9QqoS51ZCooAcNvzv1AQ3VWdT52D0ksr1+/faeK8HVIej1bxXcP75YcqH3KPA==",
+      "dev": true,
+      "dependencies": {
+        "bigint-mod-arith": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10.4.0"
+      }
+    },
+    "node_modules/bigint-mod-arith": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
+      "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.4.0"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.0.1",
@@ -5121,6 +5420,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/browser-level": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
+      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+      "dev": true,
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.1",
+        "module-error": "^1.0.2",
+        "run-parallel-limit": "^1.1.0"
+      }
+    },
     "node_modules/browser-stdout": {
       "version": "1.3.1",
       "dev": true,
@@ -5263,6 +5574,18 @@
         "node": ">=6.14.2"
       }
     },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
     "node_modules/bytes": {
       "version": "3.1.0",
       "dev": true,
@@ -5343,6 +5666,15 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/cbor": {
       "version": "5.2.0",
       "dev": true,
@@ -5401,9 +5733,16 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "3.5.2",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
-      "license": "MIT",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
       "dependencies": {
         "anymatch": "~3.1.2",
         "braces": "~3.0.2",
@@ -5468,6 +5807,32 @@
       "version": "1.1.0",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/classic-level": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
+      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "dependencies": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "~2.0.0",
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/cli-table3": {
       "version": "0.6.0",
@@ -5713,16 +6078,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/core-js-pure": {
-      "version": "3.19.2",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/core-js"
-      }
-    },
     "node_modules/core-util-is": {
       "version": "1.0.2",
       "dev": true,
@@ -5876,9 +6231,10 @@
       "dev": true
     },
     "node_modules/debug": {
-      "version": "4.3.1",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
         "ms": "2.1.2"
       },
@@ -5968,33 +6324,6 @@
       "version": "1.1.3",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/deferred-leveldown": {
-      "version": "5.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abstract-leveldown": "~6.2.1",
-        "inherits": "^2.0.3"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/deferred-leveldown/node_modules/abstract-leveldown": {
-      "version": "6.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
     },
     "node_modules/define-properties": {
       "version": "1.1.3",
@@ -6185,20 +6514,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/encoding-down": {
-      "version": "6.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "abstract-leveldown": "^6.2.1",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.4",
       "dev": true,
@@ -6224,17 +6539,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/errno": {
-      "version": "0.1.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "prr": "~1.0.1"
-      },
-      "bin": {
-        "errno": "cli.js"
       }
     },
     "node_modules/error-ex": {
@@ -6371,6 +6675,15 @@
       "dependencies": {
         "d": "^1.0.1",
         "ext": "^1.1.2"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -6674,22 +6987,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/eslint/node_modules/debug": {
-      "version": "4.3.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
       }
     },
     "node_modules/eslint/node_modules/escape-string-regexp": {
@@ -7072,31 +7369,6 @@
         "xhr-request-promise": "^0.1.2"
       }
     },
-    "node_modules/eth-sig-util": {
-      "version": "2.5.4",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "ethereumjs-abi": "0.6.8",
-        "ethereumjs-util": "^5.1.1",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.0"
-      }
-    },
-    "node_modules/eth-sig-util/node_modules/ethereumjs-util": {
-      "version": "5.2.1",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "^0.1.3",
-        "rlp": "^2.0.0",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "node_modules/ethereum-bloom-filters": {
       "version": "1.0.9",
       "dev": true,
@@ -7147,6 +7419,7 @@
     },
     "node_modules/ethereumjs-abi": {
       "version": "0.6.8",
+      "resolved": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7154,10 +7427,11 @@
         "ethereumjs-util": "^6.0.0"
       }
     },
-    "node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
+    "node_modules/ethereumjs-util": {
       "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "dev": true,
-      "license": "MPL-2.0",
       "dependencies": {
         "@types/bn.js": "^4.11.3",
         "bn.js": "^4.11.0",
@@ -7167,34 +7441,6 @@
         "ethjs-util": "0.1.6",
         "rlp": "^2.2.3"
       }
-    },
-    "node_modules/ethereumjs-util": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      },
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
-    "node_modules/ethereumjs-util/node_modules/@types/bn.js": {
-      "version": "5.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/ethereumjs-util/node_modules/bn.js": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/ethers": {
       "version": "5.5.1",
@@ -8068,6 +8314,20 @@
       "version": "1.0.0",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -9742,14 +10002,6 @@
       "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.11"
-      }
-    },
-    "node_modules/ganache-core/node_modules/async-eventemitter": {
-      "version": "0.2.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "async": "^2.4.0"
       }
     },
     "node_modules/ganache-core/node_modules/async-limiter": {
@@ -12620,15 +12872,6 @@
         "setimmediate": "^1.0.5"
       }
     },
-    "node_modules/ganache-core/node_modules/ethereumjs-abi": {
-      "version": "0.6.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
-      }
-    },
     "node_modules/ganache-core/node_modules/ethereumjs-account": {
       "version": "3.0.0",
       "dev": true,
@@ -12863,20 +13106,6 @@
       "dependencies": {
         "ethereumjs-common": "^1.5.0",
         "ethereumjs-util": "^6.0.0"
-      }
-    },
-    "node_modules/ganache-core/node_modules/ethereumjs-util": {
-      "version": "6.2.1",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.3"
       }
     },
     "node_modules/ganache-core/node_modules/ethereumjs-vm": {
@@ -13806,22 +14035,6 @@
       "license": "MIT",
       "dependencies": {
         "assert-plus": "^1.0.0"
-      }
-    },
-    "node_modules/ganache-core/node_modules/glob": {
-      "version": "7.1.3",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.0.4",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ganache-core/node_modules/global": {
@@ -16110,11 +16323,6 @@
         "rlp": "bin/rlp"
       }
     },
-    "node_modules/ganache-core/node_modules/rustbn.js": {
-      "version": "0.2.0",
-      "dev": true,
-      "license": "(MIT OR Apache-2.0)"
-    },
     "node_modules/ganache-core/node_modules/safe-buffer": {
       "version": "5.2.1",
       "dev": true,
@@ -17172,16 +17380,6 @@
         "node": "*"
       }
     },
-    "node_modules/ganache-core/node_modules/tweetnacl": {
-      "version": "1.0.3",
-      "dev": true,
-      "license": "Unlicense"
-    },
-    "node_modules/ganache-core/node_modules/tweetnacl-util": {
-      "version": "0.15.1",
-      "dev": true,
-      "license": "Unlicense"
-    },
     "node_modules/ganache-core/node_modules/type": {
       "version": "1.2.0",
       "dev": true,
@@ -17821,29 +18019,6 @@
         "ethereumjs-util": "^5.1.1"
       }
     },
-    "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-abi": {
-      "version": "0.6.8",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "bn.js": "^4.11.8",
-        "ethereumjs-util": "^6.0.0"
-      }
-    },
-    "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-abi/node_modules/ethereumjs-util": {
-      "version": "6.2.1",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@types/bn.js": "^4.11.3",
-        "bn.js": "^4.11.0",
-        "create-hash": "^1.1.2",
-        "elliptic": "^6.5.2",
-        "ethereum-cryptography": "^0.1.3",
-        "ethjs-util": "0.1.6",
-        "rlp": "^2.2.3"
-      }
-    },
     "node_modules/ganache-core/node_modules/web3-provider-engine/node_modules/ethereumjs-account": {
       "version": "2.0.5",
       "dev": true,
@@ -18414,9 +18589,10 @@
       }
     },
     "node_modules/glob": {
-      "version": "7.1.6",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
-      "license": "ISC",
       "dependencies": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -18584,22 +18760,30 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.7.0",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.2.tgz",
+      "integrity": "sha512-f3ZhzXy1uyQv0UXnAQ8GCBOWjzv++WJNb7bnm10SsyC3dB7vlPpsMWBNhq7aoRxKrNhX9tCev81KFV3i5BTeMQ==",
       "dev": true,
-      "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
-        "@ethereumjs/block": "^3.4.0",
-        "@ethereumjs/blockchain": "^5.4.0",
-        "@ethereumjs/common": "^2.4.0",
-        "@ethereumjs/tx": "^3.3.0",
-        "@ethereumjs/vm": "^5.5.2",
         "@ethersproject/abi": "^5.1.2",
+        "@metamask/eth-sig-util": "^4.0.0",
+        "@nomicfoundation/ethereumjs-block": "^4.0.0",
+        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-vm": "^6.0.0",
+        "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
-        "@solidity-parser/parser": "^0.14.0",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
         "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
+        "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
         "chalk": "^2.4.2",
         "chokidar": "^3.4.0",
@@ -18607,32 +18791,28 @@
         "debug": "^4.1.1",
         "enquirer": "^2.3.0",
         "env-paths": "^2.2.0",
-        "eth-sig-util": "^2.5.2",
-        "ethereum-cryptography": "^0.1.2",
+        "ethereum-cryptography": "^1.0.3",
         "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-util": "^7.1.0",
         "find-up": "^2.1.0",
         "fp-ts": "1.19.3",
         "fs-extra": "^7.0.1",
-        "glob": "^7.1.3",
-        "https-proxy-agent": "^5.0.0",
+        "glob": "7.2.0",
         "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
+        "keccak": "^3.0.2",
         "lodash": "^4.17.11",
-        "merkle-patricia-tree": "^4.2.0",
         "mnemonist": "^0.38.0",
-        "mocha": "^7.1.2",
-        "node-fetch": "^2.6.0",
+        "mocha": "^10.0.0",
+        "p-map": "^4.0.0",
         "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
-        "slash": "^3.0.0",
         "solc": "0.7.3",
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
-        "true-case-path": "^2.2.1",
         "tsort": "0.0.1",
+        "undici": "^5.4.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
@@ -18640,7 +18820,19 @@
         "hardhat": "internal/cli/cli.js"
       },
       "engines": {
-        "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
+        "node": "^14.0.0 || ^16.0.0 || ^18.0.0"
+      },
+      "peerDependencies": {
+        "ts-node": "*",
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "ts-node": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/hardhat-contract-sizer": {
@@ -18692,6 +18884,348 @@
         "@types/node": "*"
       }
     },
+    "node_modules/hardhat/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/hardhat/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
+    },
+    "node_modules/hardhat/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/hardhat/node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/diff": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+      "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/hardhat/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/hardhat/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/ethereum-cryptography": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+      "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "1.1.2",
+        "@noble/secp256k1": "1.6.3",
+        "@scure/bip32": "1.1.0",
+        "@scure/bip39": "1.1.0"
+      }
+    },
+    "node_modules/hardhat/node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "dev": true,
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
+    "node_modules/hardhat/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/hardhat/node_modules/locate-path": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+      "dev": true,
+      "dependencies": {
+        "p-locate": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/log-symbols/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/hardhat/node_modules/log-symbols/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/minimatch": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+      "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hardhat/node_modules/mocha": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.1.0.tgz",
+      "integrity": "sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==",
+      "dev": true,
+      "dependencies": {
+        "ansi-colors": "4.1.1",
+        "browser-stdout": "1.3.1",
+        "chokidar": "3.5.3",
+        "debug": "4.3.4",
+        "diff": "5.0.0",
+        "escape-string-regexp": "4.0.0",
+        "find-up": "5.0.0",
+        "glob": "7.2.0",
+        "he": "1.2.0",
+        "js-yaml": "4.1.0",
+        "log-symbols": "4.1.0",
+        "minimatch": "5.0.1",
+        "ms": "2.1.3",
+        "nanoid": "3.3.3",
+        "serialize-javascript": "6.0.0",
+        "strip-json-comments": "3.1.1",
+        "supports-color": "8.1.1",
+        "workerpool": "6.2.1",
+        "yargs": "16.2.0",
+        "yargs-parser": "20.2.4",
+        "yargs-unparser": "2.0.0"
+      },
+      "bin": {
+        "_mocha": "bin/_mocha",
+        "mocha": "bin/mocha.js"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mochajs"
+      }
+    },
+    "node_modules/hardhat/node_modules/mocha/node_modules/find-up": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+      "dev": true,
+      "dependencies": {
+        "locate-path": "^6.0.0",
+        "path-exists": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/hardhat/node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "dev": true,
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/hardhat/node_modules/path-exists": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/hardhat/node_modules/semver": {
       "version": "6.3.0",
       "dev": true,
@@ -18700,12 +19234,109 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/hardhat/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/hardhat/node_modules/supports-color": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+      "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
+      }
+    },
     "node_modules/hardhat/node_modules/uuid": {
       "version": "8.3.2",
       "dev": true,
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/hardhat/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/hardhat/node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hardhat/node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dev": true,
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hardhat/node_modules/yargs-parser": {
+      "version": "20.2.4",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+      "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/hardhat/node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/has": {
@@ -18978,11 +19609,6 @@
         "node": ">= 4"
       }
     },
-    "node_modules/immediate": {
-      "version": "3.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/immutable": {
       "version": "4.0.0",
       "dev": true,
@@ -19009,6 +19635,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -19481,6 +20116,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-url": {
       "version": "1.2.4",
       "dev": true,
@@ -19631,13 +20278,15 @@
       }
     },
     "node_modules/keccak": {
-      "version": "3.0.1",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
       "dev": true,
       "hasInstallScript": true,
-      "license": "MIT",
       "dependencies": {
         "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
       },
       "engines": {
         "node": ">=10.0.0"
@@ -19686,110 +20335,67 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/level-codec": {
-      "version": "9.0.2",
+    "node_modules/level": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
+      "integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "buffer": "^5.6.0"
+        "browser-level": "^1.0.1",
+        "classic-level": "^1.2.0"
       },
       "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/level-concat-iterator": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/level-errors": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "errno": "~0.1.1"
+        "node": ">=12"
       },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/level-iterator-stream": {
-      "version": "4.0.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0",
-        "xtend": "^4.0.2"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/level-mem": {
-      "version": "5.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "level-packager": "^5.0.3",
-        "memdown": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/level-packager": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "encoding-down": "^6.3.0",
-        "levelup": "^4.3.2"
-      },
-      "engines": {
-        "node": ">=6"
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/level"
       }
     },
     "node_modules/level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/level-transcoder": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "xtend": "^4.0.2"
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
     },
-    "node_modules/level-ws": {
-      "version": "2.0.0",
+    "node_modules/level-transcoder/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
       "dev": true,
-      "license": "MIT",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
       "dependencies": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.0",
-        "xtend": "^4.0.1"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/levelup": {
-      "version": "4.4.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deferred-leveldown": "~5.3.0",
-        "level-errors": "~2.0.0",
-        "level-iterator-stream": "~4.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/levn": {
@@ -19886,11 +20492,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/ltgt": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/make-error": {
       "version": "1.3.6",
       "dev": true,
@@ -19903,8 +20504,9 @@
     },
     "node_modules/mcl-wasm": {
       "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
+      "integrity": "sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=8.9.0"
       }
@@ -19927,41 +20529,19 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/memdown": {
-      "version": "5.1.0",
+    "node_modules/memory-level": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
+      "integrity": "sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "abstract-leveldown": "~6.2.1",
-        "functional-red-black-tree": "~1.0.1",
-        "immediate": "~3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.2.0"
+        "abstract-level": "^1.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "module-error": "^1.0.1"
       },
       "engines": {
-        "node": ">=6"
+        "node": ">=12"
       }
-    },
-    "node_modules/memdown/node_modules/abstract-leveldown": {
-      "version": "6.2.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/memdown/node_modules/immediate": {
-      "version": "3.2.3",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/memorystream": {
       "version": "0.3.1",
@@ -19981,20 +20561,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/merkle-patricia-tree": {
-      "version": "4.2.2",
-      "dev": true,
-      "license": "MPL-2.0",
-      "dependencies": {
-        "@types/levelup": "^4.3.0",
-        "ethereumjs-util": "^7.1.2",
-        "level-mem": "^5.0.1",
-        "level-ws": "^2.0.0",
-        "readable-stream": "^3.6.0",
-        "rlp": "^2.2.4",
-        "semaphore-async-await": "^1.5.1"
       }
     },
     "node_modules/methods": {
@@ -20236,6 +20802,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/mocha/node_modules/fsevents": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+      "deprecated": "\"Please update to latest v2.3 or v2.2\"",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/mocha/node_modules/glob": {
       "version": "7.1.3",
       "dev": true,
@@ -20337,6 +20918,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "dev": true,
@@ -20387,6 +20977,24 @@
       "version": "0.1.2",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/napi-macros": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
+      "dev": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -20455,9 +21063,10 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.2.3",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "dev": true,
-      "license": "MIT",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -20724,6 +21333,21 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "dependencies": {
+        "aggregate-error": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/p-timeout": {
@@ -21112,11 +21736,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/prr": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -21606,10 +22225,34 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/run-parallel-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "node_modules/rustbn.js": {
       "version": "0.2.0",
-      "dev": true,
-      "license": "(MIT OR Apache-2.0)"
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
+      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
+      "dev": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -21734,14 +22377,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/semaphore-async-await": {
-      "version": "1.5.1",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.1"
-      }
-    },
     "node_modules/semver": {
       "version": "7.3.5",
       "dev": true,
@@ -21796,6 +22431,15 @@
       "version": "2.1.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "dependencies": {
+        "randombytes": "^2.1.0"
+      }
     },
     "node_modules/serve-static": {
       "version": "1.14.1",
@@ -22212,6 +22856,15 @@
       "license": "ISC",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/strict-uri-encode": {
@@ -22636,11 +23289,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/true-case-path": {
-      "version": "2.2.1",
-      "dev": true,
-      "license": "Apache-2.0"
-    },
     "node_modules/ts-essentials": {
       "version": "1.0.4",
       "dev": true,
@@ -22750,13 +23398,15 @@
     },
     "node_modules/tweetnacl": {
       "version": "1.0.3",
-      "dev": true,
-      "license": "Unlicense"
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
+      "dev": true
     },
     "node_modules/tweetnacl-util": {
       "version": "0.15.1",
-      "dev": true,
-      "license": "Unlicense"
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
+      "dev": true
     },
     "node_modules/type": {
       "version": "1.2.0",
@@ -22912,6 +23562,18 @@
       "version": "1.9.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
+      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+      "dev": true,
+      "dependencies": {
+        "busboy": "^1.6.0"
+      },
+      "engines": {
+        "node": ">=12.18"
+      }
     },
     "node_modules/unfetch": {
       "version": "4.2.0",
@@ -23872,6 +24534,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
     "node_modules/wrap-ansi": {
       "version": "5.1.0",
       "dev": true,
@@ -24151,6 +24819,18 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     }
   },
   "dependencies": {
@@ -24330,13 +25010,6 @@
           "version": "2.0.1",
           "dev": true
         },
-        "debug": {
-          "version": "4.3.3",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
         "ignore": {
           "version": "4.0.6",
           "dev": true
@@ -24468,76 +25141,6 @@
         "postinstall-postinstall": "^2.1.0"
       }
     },
-    "@ethereumjs/block": {
-      "version": "3.6.0",
-      "dev": true,
-      "requires": {
-        "@ethereumjs/common": "^2.6.0",
-        "@ethereumjs/tx": "^3.4.0",
-        "ethereumjs-util": "^7.1.3",
-        "merkle-patricia-tree": "^4.2.2"
-      },
-      "dependencies": {
-        "@ethereumjs/common": {
-          "version": "2.6.0",
-          "dev": true,
-          "requires": {
-            "crc-32": "^1.2.0",
-            "ethereumjs-util": "^7.1.3"
-          }
-        },
-        "@ethereumjs/tx": {
-          "version": "3.4.0",
-          "dev": true,
-          "requires": {
-            "@ethereumjs/common": "^2.6.0",
-            "ethereumjs-util": "^7.1.3"
-          }
-        }
-      }
-    },
-    "@ethereumjs/blockchain": {
-      "version": "5.5.1",
-      "dev": true,
-      "requires": {
-        "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/common": "^2.6.0",
-        "@ethereumjs/ethash": "^1.1.0",
-        "debug": "^2.2.0",
-        "ethereumjs-util": "^7.1.3",
-        "level-mem": "^5.0.1",
-        "lru-cache": "^5.1.1",
-        "semaphore-async-await": "^1.5.1"
-      },
-      "dependencies": {
-        "@ethereumjs/common": {
-          "version": "2.6.0",
-          "dev": true,
-          "requires": {
-            "crc-32": "^1.2.0",
-            "ethereumjs-util": "^7.1.3"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "lru-cache": {
-          "version": "5.1.1",
-          "dev": true,
-          "requires": {
-            "yallist": "^3.0.2"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "dev": true
-        }
-      }
-    },
     "@ethereumjs/common": {
       "version": "2.4.0",
       "dev": true,
@@ -24567,26 +25170,6 @@
             "ethereum-cryptography": "^0.1.3",
             "ethjs-util": "0.1.6",
             "rlp": "^2.2.4"
-          }
-        }
-      }
-    },
-    "@ethereumjs/ethash": {
-      "version": "1.1.0",
-      "dev": true,
-      "requires": {
-        "@ethereumjs/block": "^3.5.0",
-        "@types/levelup": "^4.3.0",
-        "buffer-xor": "^2.0.1",
-        "ethereumjs-util": "^7.1.1",
-        "miller-rabin": "^4.0.0"
-      },
-      "dependencies": {
-        "buffer-xor": {
-          "version": "2.0.2",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "^5.1.1"
           }
         }
       }
@@ -24621,53 +25204,6 @@
             "ethjs-util": "0.1.6",
             "rlp": "^2.2.4"
           }
-        }
-      }
-    },
-    "@ethereumjs/vm": {
-      "version": "5.6.0",
-      "dev": true,
-      "requires": {
-        "@ethereumjs/block": "^3.6.0",
-        "@ethereumjs/blockchain": "^5.5.0",
-        "@ethereumjs/common": "^2.6.0",
-        "@ethereumjs/tx": "^3.4.0",
-        "async-eventemitter": "^0.2.4",
-        "core-js-pure": "^3.0.1",
-        "debug": "^2.2.0",
-        "ethereumjs-util": "^7.1.3",
-        "functional-red-black-tree": "^1.0.1",
-        "mcl-wasm": "^0.7.1",
-        "merkle-patricia-tree": "^4.2.2",
-        "rustbn.js": "~0.2.0"
-      },
-      "dependencies": {
-        "@ethereumjs/common": {
-          "version": "2.6.0",
-          "dev": true,
-          "requires": {
-            "crc-32": "^1.2.0",
-            "ethereumjs-util": "^7.1.3"
-          }
-        },
-        "@ethereumjs/tx": {
-          "version": "3.4.0",
-          "dev": true,
-          "requires": {
-            "@ethereumjs/common": "^2.6.0",
-            "ethereumjs-util": "^7.1.3"
-          }
-        },
-        "debug": {
-          "version": "2.6.9",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "dev": true
         }
       }
     },
@@ -26122,6 +26658,31 @@
       "version": "1.2.1",
       "dev": true
     },
+    "@metamask/eth-sig-util": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@metamask/eth-sig-util/-/eth-sig-util-4.0.1.tgz",
+      "integrity": "sha512-tghyZKLHZjcdlDqCA3gNZmLeR0XvOE9U1qoQO9ohyAZT6Pya+H9vkBPcsyXytmYLNgVoin7CKCmweo/R43V+tQ==",
+      "dev": true,
+      "requires": {
+        "ethereumjs-abi": "^0.6.8",
+        "ethereumjs-util": "^6.2.1",
+        "ethjs-util": "^0.1.6",
+        "tweetnacl": "^1.0.3",
+        "tweetnacl-util": "^0.15.1"
+      }
+    },
+    "@noble/hashes": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
+      "integrity": "sha512-KYRCASVTv6aeUi1tsF8/vpyR7zpfs3FUzy2Jqm+MU+LmUKhQ0y2FpfwqkCcxSg2ua4GALJd8k2R76WxwZGbQpA==",
+      "dev": true
+    },
+    "@noble/secp256k1": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/@noble/secp256k1/-/secp256k1-1.6.3.tgz",
+      "integrity": "sha512-T04e4iTurVy7I8Sw4+c5OSN9/RkPlo1uKxAomtxQNLq8j1uPAqnsqG1bqvY3Jv7c13gyr6dui0zmh/I3+f/JaQ==",
+      "dev": true
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.4",
       "dev": true,
@@ -26141,6 +26702,258 @@
         "@nodelib/fs.scandir": "2.1.4",
         "fastq": "^1.6.0"
       }
+    },
+    "@nomicfoundation/ethereumjs-block": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-block/-/ethereumjs-block-4.0.0.tgz",
+      "integrity": "sha512-bk8uP8VuexLgyIZAHExH1QEovqx0Lzhc9Ntm63nCRKLHXIZkobaFaeCVwTESV7YkPKUk7NiK11s8ryed4CS9yA==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "ethereum-cryptography": "0.1.3"
+      }
+    },
+    "@nomicfoundation/ethereumjs-blockchain": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-blockchain/-/ethereumjs-blockchain-6.0.0.tgz",
+      "integrity": "sha512-pLFEoea6MWd81QQYSReLlLfH7N9v7lH66JC/NMPN848ySPPQA5renWnE7wPByfQFzNrPBuDDRFFULMDmj1C0xw==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/ethereumjs-block": "^4.0.0",
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-ethash": "^2.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "abstract-level": "^1.0.3",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "level": "^8.0.0",
+        "lru-cache": "^5.1.1",
+        "memory-level": "^1.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        }
+      }
+    },
+    "@nomicfoundation/ethereumjs-common": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-common/-/ethereumjs-common-3.0.0.tgz",
+      "integrity": "sha512-WS7qSshQfxoZOpHG/XqlHEGRG1zmyjYrvmATvc4c62+gZXgre1ymYP8ZNgx/3FyZY0TWe9OjFlKOfLqmgOeYwA==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "crc-32": "^1.2.0"
+      }
+    },
+    "@nomicfoundation/ethereumjs-ethash": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-ethash/-/ethereumjs-ethash-2.0.0.tgz",
+      "integrity": "sha512-WpDvnRncfDUuXdsAXlI4lXbqUDOA+adYRQaEezIkxqDkc+LDyYDbd/xairmY98GnQzo1zIqsIL6GB5MoMSJDew==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/ethereumjs-block": "^4.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "abstract-level": "^1.0.3",
+        "bigint-crypto-utils": "^3.0.23",
+        "ethereum-cryptography": "0.1.3"
+      }
+    },
+    "@nomicfoundation/ethereumjs-evm": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-evm/-/ethereumjs-evm-1.0.0.tgz",
+      "integrity": "sha512-hVS6qRo3V1PLKCO210UfcEQHvlG7GqR8iFzp0yyjTg2TmJQizcChKgWo8KFsdMw6AyoLgLhHGHw4HdlP8a4i+Q==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@types/async-eventemitter": "^0.2.1",
+        "async-eventemitter": "^0.2.4",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "mcl-wasm": "^0.7.1",
+        "rustbn.js": "~0.2.0"
+      }
+    },
+    "@nomicfoundation/ethereumjs-rlp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-rlp/-/ethereumjs-rlp-4.0.0.tgz",
+      "integrity": "sha512-GaSOGk5QbUk4eBP5qFbpXoZoZUj/NrW7MRa0tKY4Ew4c2HAS0GXArEMAamtFrkazp0BO4K5p2ZCG3b2FmbShmw==",
+      "dev": true
+    },
+    "@nomicfoundation/ethereumjs-statemanager": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-statemanager/-/ethereumjs-statemanager-1.0.0.tgz",
+      "integrity": "sha512-jCtqFjcd2QejtuAMjQzbil/4NHf5aAWxUc+CvS0JclQpl+7M0bxMofR2AJdtz+P3u0ke2euhYREDiE7iSO31vQ==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "functional-red-black-tree": "^1.0.1"
+      }
+    },
+    "@nomicfoundation/ethereumjs-trie": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-trie/-/ethereumjs-trie-5.0.0.tgz",
+      "integrity": "sha512-LIj5XdE+s+t6WSuq/ttegJzZ1vliwg6wlb+Y9f4RlBpuK35B9K02bO7xU+E6Rgg9RGptkWd6TVLdedTI4eNc2A==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "ethereum-cryptography": "0.1.3",
+        "readable-stream": "^3.6.0"
+      }
+    },
+    "@nomicfoundation/ethereumjs-tx": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-tx/-/ethereumjs-tx-4.0.0.tgz",
+      "integrity": "sha512-Gg3Lir2lNUck43Kp/3x6TfBNwcWC9Z1wYue9Nz3v4xjdcv6oDW9QSMJxqsKw9QEGoBBZ+gqwpW7+F05/rs/g1w==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "ethereum-cryptography": "0.1.3"
+      }
+    },
+    "@nomicfoundation/ethereumjs-util": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-util/-/ethereumjs-util-8.0.0.tgz",
+      "integrity": "sha512-2emi0NJ/HmTG+CGY58fa+DQuAoroFeSH9gKu9O6JnwTtlzJtgfTixuoOqLEgyyzZVvwfIpRueuePb8TonL1y+A==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0-beta.2",
+        "ethereum-cryptography": "0.1.3"
+      }
+    },
+    "@nomicfoundation/ethereumjs-vm": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/ethereumjs-vm/-/ethereumjs-vm-6.0.0.tgz",
+      "integrity": "sha512-JMPxvPQ3fzD063Sg3Tp+UdwUkVxMoo1uML6KSzFhMH3hoQi/LMuXBoEHAoW83/vyNS9BxEe6jm6LmT5xdeEJ6w==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/ethereumjs-block": "^4.0.0",
+        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@types/async-eventemitter": "^0.2.1",
+        "async-eventemitter": "^0.2.4",
+        "debug": "^4.3.3",
+        "ethereum-cryptography": "0.1.3",
+        "functional-red-black-tree": "^1.0.1",
+        "mcl-wasm": "^0.7.1",
+        "rustbn.js": "~0.2.0"
+      }
+    },
+    "@nomicfoundation/solidity-analyzer": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer/-/solidity-analyzer-0.1.0.tgz",
+      "integrity": "sha512-xGWAiVCGOycvGiP/qrlf9f9eOn7fpNbyJygcB0P21a1MDuVPlKt0Srp7rvtBEutYQ48ouYnRXm33zlRnlTOPHg==",
+      "dev": true,
+      "requires": {
+        "@nomicfoundation/solidity-analyzer-darwin-arm64": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-darwin-x64": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-freebsd-x64": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-linux-arm64-musl": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-linux-x64-gnu": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-linux-x64-musl": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": "0.1.0",
+        "@nomicfoundation/solidity-analyzer-win32-x64-msvc": "0.1.0"
+      }
+    },
+    "@nomicfoundation/solidity-analyzer-darwin-arm64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-arm64/-/solidity-analyzer-darwin-arm64-0.1.0.tgz",
+      "integrity": "sha512-vEF3yKuuzfMHsZecHQcnkUrqm8mnTWfJeEVFHpg+cO+le96xQA4lAJYdUan8pXZohQxv1fSReQsn4QGNuBNuCw==",
+      "dev": true,
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-darwin-x64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-darwin-x64/-/solidity-analyzer-darwin-x64-0.1.0.tgz",
+      "integrity": "sha512-dlHeIg0pTL4dB1l9JDwbi/JG6dHQaU1xpDK+ugYO8eJ1kxx9Dh2isEUtA4d02cQAl22cjOHTvifAk96A+ItEHA==",
+      "dev": true,
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-freebsd-x64": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-freebsd-x64/-/solidity-analyzer-freebsd-x64-0.1.0.tgz",
+      "integrity": "sha512-WFCZYMv86WowDA4GiJKnebMQRt3kCcFqHeIomW6NMyqiKqhK1kIZCxSLDYsxqlx396kKLPN1713Q1S8tu68GKg==",
+      "dev": true,
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-linux-arm64-gnu": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-gnu/-/solidity-analyzer-linux-arm64-gnu-0.1.0.tgz",
+      "integrity": "sha512-DTw6MNQWWlCgc71Pq7CEhEqkb7fZnS7oly13pujs4cMH1sR0JzNk90Mp1zpSCsCs4oKan2ClhMlLKtNat/XRKQ==",
+      "dev": true,
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-linux-arm64-musl": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-arm64-musl/-/solidity-analyzer-linux-arm64-musl-0.1.0.tgz",
+      "integrity": "sha512-wUpUnR/3GV5Da88MhrxXh/lhb9kxh9V3Jya2NpBEhKDIRCDmtXMSqPMXHZmOR9DfCwCvG6vLFPr/+YrPCnUN0w==",
+      "dev": true,
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-linux-x64-gnu": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-gnu/-/solidity-analyzer-linux-x64-gnu-0.1.0.tgz",
+      "integrity": "sha512-lR0AxK1x/MeKQ/3Pt923kPvwigmGX3OxeU5qNtQ9pj9iucgk4PzhbS3ruUeSpYhUxG50jN4RkIGwUMoev5lguw==",
+      "dev": true,
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-linux-x64-musl": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-linux-x64-musl/-/solidity-analyzer-linux-x64-musl-0.1.0.tgz",
+      "integrity": "sha512-A1he/8gy/JeBD3FKvmI6WUJrGrI5uWJNr5Xb9WdV+DK0F8msuOqpEByLlnTdLkXMwW7nSl3awvLezOs9xBHJEg==",
+      "dev": true,
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-win32-arm64-msvc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-arm64-msvc/-/solidity-analyzer-win32-arm64-msvc-0.1.0.tgz",
+      "integrity": "sha512-7x5SXZ9R9H4SluJZZP8XPN+ju7Mx+XeUMWZw7ZAqkdhP5mK19I4vz3x0zIWygmfE8RT7uQ5xMap0/9NPsO+ykw==",
+      "dev": true,
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-win32-ia32-msvc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-ia32-msvc/-/solidity-analyzer-win32-ia32-msvc-0.1.0.tgz",
+      "integrity": "sha512-m7w3xf+hnE774YRXu+2mGV7RiF3QJtUoiYU61FascCkQhX3QMQavh7saH/vzb2jN5D24nT/jwvaHYX/MAM9zUw==",
+      "dev": true,
+      "optional": true
+    },
+    "@nomicfoundation/solidity-analyzer-win32-x64-msvc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/solidity-analyzer-win32-x64-msvc/-/solidity-analyzer-win32-x64-msvc-0.1.0.tgz",
+      "integrity": "sha512-xCuybjY0sLJQnJhupiFAXaek2EqF0AP0eBjgzaalPXSNvCEN6ZYHvUzdA50ENDVeSYFXcUsYf3+FsD3XKaeptA==",
+      "dev": true,
+      "optional": true
     },
     "@nomiclabs/hardhat-ethers": {
       "version": "2.0.2",
@@ -26242,6 +27055,33 @@
             "ms": "^2.1.1"
           }
         }
+      }
+    },
+    "@scure/base": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.1.tgz",
+      "integrity": "sha512-ZxOhsSyxYwLJj3pLZCefNitxsj093tb2vq90mp2txoYeBqbcjDjqFhyM8eUjq/uFm6zJ+mUuqxlS2FkuSY1MTA==",
+      "dev": true
+    },
+    "@scure/bip32": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.1.0.tgz",
+      "integrity": "sha512-ftTW3kKX54YXLCxH6BB7oEEoJfoE2pIgw7MINKAs5PsS6nqKPuKk1haTF/EuHmYqG330t5GSrdmtRuHaY1a62Q==",
+      "dev": true,
+      "requires": {
+        "@noble/hashes": "~1.1.1",
+        "@noble/secp256k1": "~1.6.0",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "@scure/bip39": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
+      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
+      "dev": true,
+      "requires": {
+        "@noble/hashes": "~1.1.1",
+        "@scure/base": "~1.1.0"
       }
     },
     "@sentry/core": {
@@ -26464,8 +27304,10 @@
         }
       }
     },
-    "@types/abstract-leveldown": {
-      "version": "5.0.2",
+    "@types/async-eventemitter": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@types/async-eventemitter/-/async-eventemitter-0.2.1.tgz",
+      "integrity": "sha512-M2P4Ng26QbAeITiH7w1d7OxtldgfAe0wobpyJzVK/XOb0cUGKU2R4pfAhqcJBXAe2ife5ZOhSv4wk7p+ffURtg==",
       "dev": true
     },
     "@types/bn.js": {
@@ -26504,19 +27346,6 @@
     "@types/json-schema": {
       "version": "7.0.9",
       "dev": true
-    },
-    "@types/level-errors": {
-      "version": "3.0.0",
-      "dev": true
-    },
-    "@types/levelup": {
-      "version": "4.3.3",
-      "dev": true,
-      "requires": {
-        "@types/abstract-leveldown": "*",
-        "@types/level-errors": "*",
-        "@types/node": "*"
-      }
     },
     "@types/lru-cache": {
       "version": "5.1.1",
@@ -26590,15 +27419,6 @@
         "regexpp": "^3.2.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "@typescript-eslint/experimental-utils": {
@@ -26621,15 +27441,6 @@
         "@typescript-eslint/types": "5.5.0",
         "@typescript-eslint/typescript-estree": "5.5.0",
         "debug": "^4.3.2"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        }
       }
     },
     "@typescript-eslint/scope-manager": {
@@ -26657,13 +27468,6 @@
         "tsutils": "^3.21.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "4.3.3",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
         "is-glob": {
           "version": "4.0.3",
           "dev": true,
@@ -26696,15 +27500,31 @@
         "event-target-shim": "^5.0.0"
       }
     },
-    "abstract-leveldown": {
-      "version": "6.3.0",
+    "abstract-level": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/abstract-level/-/abstract-level-1.0.3.tgz",
+      "integrity": "sha512-t6jv+xHy+VYwc4xqZMn2Pa9DjcdzvzZmQGRjTFc8spIbRGHgBrEKbPq+rYXc7CCo0lxgYvSgKVg9qZAhpVQSjA==",
       "dev": true,
       "requires": {
-        "buffer": "^5.5.0",
-        "immediate": "^3.2.3",
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
+        "buffer": "^6.0.3",
+        "catering": "^2.1.0",
+        "is-buffer": "^2.0.5",
+        "level-supports": "^4.0.0",
+        "level-transcoder": "^1.0.1",
+        "module-error": "^1.0.1",
+        "queue-microtask": "^1.2.3"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "accepts": {
@@ -26745,6 +27565,16 @@
       "dev": true,
       "requires": {
         "debug": "4"
+      }
+    },
+    "aggregate-error": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
+      "integrity": "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==",
+      "dev": true,
+      "requires": {
+        "clean-stack": "^2.0.0",
+        "indent-string": "^4.0.0"
       }
     },
     "ajv": {
@@ -26884,7 +27714,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.3",
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
       "dev": true,
       "requires": {
         "lodash": "^4.17.14"
@@ -26892,6 +27724,8 @@
     },
     "async-eventemitter": {
       "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/async-eventemitter/-/async-eventemitter-0.2.4.tgz",
+      "integrity": "sha512-pd20BwL7Yt1zwDFy+8MX8F1+WCT8aQeKj0kQnTrH9WaeRETlRamVhD0JtRPmrV4GfOJ2F9CvdQkZeZhnh2TuHw==",
       "dev": true,
       "requires": {
         "async": "^2.4.0"
@@ -26958,6 +27792,21 @@
     },
     "bech32": {
       "version": "1.1.4",
+      "dev": true
+    },
+    "bigint-crypto-utils": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/bigint-crypto-utils/-/bigint-crypto-utils-3.1.7.tgz",
+      "integrity": "sha512-zpCQpIE2Oy5WIQpjC9iYZf8Uh9QqoS51ZCooAcNvzv1AQ3VWdT52D0ksr1+/faeK8HVIej1bxXcP75YcqH3KPA==",
+      "dev": true,
+      "requires": {
+        "bigint-mod-arith": "^3.1.0"
+      }
+    },
+    "bigint-mod-arith": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bigint-mod-arith/-/bigint-mod-arith-3.1.2.tgz",
+      "integrity": "sha512-nx8J8bBeiRR+NlsROFH9jHswW5HO8mgfOSqW0AmjicMMvaONDa8AO+5ViKDUUNytBPWiwfvZP4/Bj4Y3lUfvgQ==",
       "dev": true
     },
     "bignumber.js": {
@@ -27070,6 +27919,18 @@
     "brorand": {
       "version": "1.1.0",
       "dev": true
+    },
+    "browser-level": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/browser-level/-/browser-level-1.0.1.tgz",
+      "integrity": "sha512-XECYKJ+Dbzw0lbydyQuJzwNXtOpbMSq737qxJN11sIRTErOMShvDpbzTlgju7orJKvx4epULolZAuJGLzCmWRQ==",
+      "dev": true,
+      "requires": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.1",
+        "module-error": "^1.0.2",
+        "run-parallel-limit": "^1.1.0"
+      }
     },
     "browser-stdout": {
       "version": "1.3.1",
@@ -27184,6 +28045,15 @@
         "node-gyp-build": "^4.2.0"
       }
     },
+    "busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dev": true,
+      "requires": {
+        "streamsearch": "^1.1.0"
+      }
+    },
     "bytes": {
       "version": "3.1.0",
       "dev": true
@@ -27234,6 +28104,12 @@
       "version": "0.12.0",
       "dev": true
     },
+    "catering": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/catering/-/catering-2.1.1.tgz",
+      "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w==",
+      "dev": true
+    },
     "cbor": {
       "version": "5.2.0",
       "dev": true,
@@ -27272,7 +28148,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.2",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
+      "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
       "dev": true,
       "requires": {
         "anymatch": "~3.1.2",
@@ -27324,6 +28202,25 @@
     },
     "class-is": {
       "version": "1.1.0",
+      "dev": true
+    },
+    "classic-level": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/classic-level/-/classic-level-1.2.0.tgz",
+      "integrity": "sha512-qw5B31ANxSluWz9xBzklRWTUAJ1SXIdaVKTVS7HcTGKOAmExx65Wo5BUICW+YGORe2FOUaDghoI9ZDxj82QcFg==",
+      "dev": true,
+      "requires": {
+        "abstract-level": "^1.0.2",
+        "catering": "^2.1.0",
+        "module-error": "^1.0.1",
+        "napi-macros": "~2.0.0",
+        "node-gyp-build": "^4.3.0"
+      }
+    },
+    "clean-stack": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-2.2.0.tgz",
+      "integrity": "sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==",
       "dev": true
     },
     "cli-table3": {
@@ -27506,10 +28403,6 @@
       "version": "2.1.2",
       "dev": true
     },
-    "core-js-pure": {
-      "version": "3.19.2",
-      "dev": true
-    },
     "core-util-is": {
       "version": "1.0.2",
       "dev": true
@@ -27627,7 +28520,9 @@
       "dev": true
     },
     "debug": {
-      "version": "4.3.1",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
+      "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
       "dev": true,
       "requires": {
         "ms": "2.1.2"
@@ -27683,27 +28578,6 @@
     "defer-to-connect": {
       "version": "1.1.3",
       "dev": true
-    },
-    "deferred-leveldown": {
-      "version": "5.3.0",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "inherits": "^2.0.3"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "6.2.3",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "immediate": "^3.2.3",
-            "level-concat-iterator": "~2.0.0",
-            "level-supports": "~1.0.0",
-            "xtend": "~4.0.0"
-          }
-        }
-      }
     },
     "define-properties": {
       "version": "1.1.3",
@@ -27840,16 +28714,6 @@
       "version": "1.0.2",
       "dev": true
     },
-    "encoding-down": {
-      "version": "6.3.0",
-      "dev": true,
-      "requires": {
-        "abstract-leveldown": "^6.2.1",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0"
-      }
-    },
     "end-of-stream": {
       "version": "1.4.4",
       "dev": true,
@@ -27867,13 +28731,6 @@
     "env-paths": {
       "version": "2.2.1",
       "dev": true
-    },
-    "errno": {
-      "version": "0.1.8",
-      "dev": true,
-      "requires": {
-        "prr": "~1.0.1"
-      }
     },
     "error-ex": {
       "version": "1.3.2",
@@ -27969,6 +28826,12 @@
         "d": "^1.0.1",
         "ext": "^1.1.2"
       }
+    },
+    "escalade": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+      "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -28119,13 +28982,6 @@
             "path-key": "^3.1.0",
             "shebang-command": "^2.0.0",
             "which": "^2.0.1"
-          }
-        },
-        "debug": {
-          "version": "4.3.3",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
           }
         },
         "escape-string-regexp": {
@@ -28425,31 +29281,6 @@
         "xhr-request-promise": "^0.1.2"
       }
     },
-    "eth-sig-util": {
-      "version": "2.5.4",
-      "dev": true,
-      "requires": {
-        "ethereumjs-abi": "0.6.8",
-        "ethereumjs-util": "^5.1.1",
-        "tweetnacl": "^1.0.3",
-        "tweetnacl-util": "^0.15.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "5.2.1",
-          "dev": true,
-          "requires": {
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "^0.1.3",
-            "rlp": "^2.0.0",
-            "safe-buffer": "^5.1.1"
-          }
-        }
-      }
-    },
     "ethereum-bloom-filters": {
       "version": "1.0.9",
       "dev": true,
@@ -28490,50 +29321,27 @@
       }
     },
     "ethereumjs-abi": {
-      "version": "0.6.8",
+      "version": "git+ssh://git@github.com/ethereumjs/ethereumjs-abi.git#ee3994657fa7a427238e6ba92a84d0b529bbcde0",
       "dev": true,
+      "from": "ethereumjs-abi@^0.6.8",
       "requires": {
         "bn.js": "^4.11.8",
         "ethereumjs-util": "^6.0.0"
-      },
-      "dependencies": {
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "dev": true,
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
-          }
-        }
       }
     },
     "ethereumjs-util": {
-      "version": "7.1.3",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-6.2.1.tgz",
+      "integrity": "sha512-W2Ktez4L01Vexijrm5EB6w7dg4n/TgpoYU4avuT5T3Vmnw/eCRtiBrJfQYS/DCSvDIOLn2k57GcHdeBcgVxAqw==",
       "dev": true,
       "requires": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
+        "@types/bn.js": "^4.11.3",
+        "bn.js": "^4.11.0",
         "create-hash": "^1.1.2",
+        "elliptic": "^6.5.2",
         "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
-      },
-      "dependencies": {
-        "@types/bn.js": {
-          "version": "5.1.0",
-          "dev": true,
-          "requires": {
-            "@types/node": "*"
-          }
-        },
-        "bn.js": {
-          "version": "5.2.0",
-          "dev": true
-        }
+        "ethjs-util": "0.1.6",
+        "rlp": "^2.2.3"
       }
     },
     "ethers": {
@@ -29087,6 +29895,13 @@
     "fs.realpath": {
       "version": "1.0.0",
       "dev": true
+    },
+    "fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "optional": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -30228,13 +31043,6 @@
           "dev": true,
           "requires": {
             "lodash": "^4.17.11"
-          }
-        },
-        "async-eventemitter": {
-          "version": "0.2.4",
-          "dev": true,
-          "requires": {
-            "async": "^2.4.0"
           }
         },
         "async-limiter": {
@@ -32635,14 +33443,6 @@
             "setimmediate": "^1.0.5"
           }
         },
-        "ethereumjs-abi": {
-          "version": "0.6.8",
-          "dev": true,
-          "requires": {
-            "bn.js": "^4.11.8",
-            "ethereumjs-util": "^6.0.0"
-          }
-        },
         "ethereumjs-account": {
           "version": "3.0.0",
           "dev": true,
@@ -32856,19 +33656,6 @@
           "requires": {
             "ethereumjs-common": "^1.5.0",
             "ethereumjs-util": "^6.0.0"
-          }
-        },
-        "ethereumjs-util": {
-          "version": "6.2.1",
-          "dev": true,
-          "requires": {
-            "@types/bn.js": "^4.11.3",
-            "bn.js": "^4.11.0",
-            "create-hash": "^1.1.2",
-            "elliptic": "^6.5.2",
-            "ethereum-cryptography": "^0.1.3",
-            "ethjs-util": "0.1.6",
-            "rlp": "^2.2.3"
           }
         },
         "ethereumjs-vm": {
@@ -33605,18 +34392,6 @@
           "dev": true,
           "requires": {
             "assert-plus": "^1.0.0"
-          }
-        },
-        "glob": {
-          "version": "7.1.3",
-          "dev": true,
-          "requires": {
-            "fs.realpath": "^1.0.0",
-            "inflight": "^1.0.4",
-            "inherits": "2",
-            "minimatch": "^3.0.4",
-            "once": "^1.3.0",
-            "path-is-absolute": "^1.0.0"
           }
         },
         "global": {
@@ -35228,10 +36003,6 @@
             "bn.js": "^4.11.1"
           }
         },
-        "rustbn.js": {
-          "version": "0.2.0",
-          "dev": true
-        },
         "safe-buffer": {
           "version": "5.2.1",
           "dev": true
@@ -35990,14 +36761,6 @@
             "safe-buffer": "^5.0.1"
           }
         },
-        "tweetnacl": {
-          "version": "1.0.3",
-          "dev": true
-        },
-        "tweetnacl-util": {
-          "version": "0.15.1",
-          "dev": true
-        },
         "type": {
           "version": "1.2.0",
           "dev": true
@@ -36486,29 +37249,6 @@
                 "ethereumjs-util": "^5.1.1"
               }
             },
-            "ethereumjs-abi": {
-              "version": "0.6.8",
-              "dev": true,
-              "requires": {
-                "bn.js": "^4.11.8",
-                "ethereumjs-util": "^6.0.0"
-              },
-              "dependencies": {
-                "ethereumjs-util": {
-                  "version": "6.2.1",
-                  "dev": true,
-                  "requires": {
-                    "@types/bn.js": "^4.11.3",
-                    "bn.js": "^4.11.0",
-                    "create-hash": "^1.1.2",
-                    "elliptic": "^6.5.2",
-                    "ethereum-cryptography": "^0.1.3",
-                    "ethjs-util": "0.1.6",
-                    "rlp": "^2.2.3"
-                  }
-                }
-              }
-            },
             "ethereumjs-account": {
               "version": "2.0.5",
               "dev": true,
@@ -36993,7 +37733,9 @@
       }
     },
     "glob": {
-      "version": "7.1.6",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
+      "integrity": "sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -37103,21 +37845,30 @@
       }
     },
     "hardhat": {
-      "version": "2.7.0",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.12.2.tgz",
+      "integrity": "sha512-f3ZhzXy1uyQv0UXnAQ8GCBOWjzv++WJNb7bnm10SsyC3dB7vlPpsMWBNhq7aoRxKrNhX9tCev81KFV3i5BTeMQ==",
       "dev": true,
       "requires": {
-        "@ethereumjs/block": "^3.4.0",
-        "@ethereumjs/blockchain": "^5.4.0",
-        "@ethereumjs/common": "^2.4.0",
-        "@ethereumjs/tx": "^3.3.0",
-        "@ethereumjs/vm": "^5.5.2",
         "@ethersproject/abi": "^5.1.2",
+        "@metamask/eth-sig-util": "^4.0.0",
+        "@nomicfoundation/ethereumjs-block": "^4.0.0",
+        "@nomicfoundation/ethereumjs-blockchain": "^6.0.0",
+        "@nomicfoundation/ethereumjs-common": "^3.0.0",
+        "@nomicfoundation/ethereumjs-evm": "^1.0.0",
+        "@nomicfoundation/ethereumjs-rlp": "^4.0.0",
+        "@nomicfoundation/ethereumjs-statemanager": "^1.0.0",
+        "@nomicfoundation/ethereumjs-trie": "^5.0.0",
+        "@nomicfoundation/ethereumjs-tx": "^4.0.0",
+        "@nomicfoundation/ethereumjs-util": "^8.0.0",
+        "@nomicfoundation/ethereumjs-vm": "^6.0.0",
+        "@nomicfoundation/solidity-analyzer": "^0.1.0",
         "@sentry/node": "^5.18.1",
-        "@solidity-parser/parser": "^0.14.0",
         "@types/bn.js": "^5.1.0",
         "@types/lru-cache": "^5.1.0",
         "abort-controller": "^3.0.0",
         "adm-zip": "^0.4.16",
+        "aggregate-error": "^3.0.0",
         "ansi-escapes": "^4.3.0",
         "chalk": "^2.4.2",
         "chokidar": "^3.4.0",
@@ -37125,32 +37876,28 @@
         "debug": "^4.1.1",
         "enquirer": "^2.3.0",
         "env-paths": "^2.2.0",
-        "eth-sig-util": "^2.5.2",
-        "ethereum-cryptography": "^0.1.2",
+        "ethereum-cryptography": "^1.0.3",
         "ethereumjs-abi": "^0.6.8",
-        "ethereumjs-util": "^7.1.0",
         "find-up": "^2.1.0",
         "fp-ts": "1.19.3",
         "fs-extra": "^7.0.1",
-        "glob": "^7.1.3",
-        "https-proxy-agent": "^5.0.0",
+        "glob": "7.2.0",
         "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
+        "keccak": "^3.0.2",
         "lodash": "^4.17.11",
-        "merkle-patricia-tree": "^4.2.0",
         "mnemonist": "^0.38.0",
-        "mocha": "^7.1.2",
-        "node-fetch": "^2.6.0",
+        "mocha": "^10.0.0",
+        "p-map": "^4.0.0",
         "qs": "^6.7.0",
         "raw-body": "^2.4.1",
         "resolve": "1.17.0",
         "semver": "^6.3.0",
-        "slash": "^3.0.0",
         "solc": "0.7.3",
         "source-map-support": "^0.5.13",
         "stacktrace-parser": "^0.1.10",
-        "true-case-path": "^2.2.1",
         "tsort": "0.0.1",
+        "undici": "^5.4.0",
         "uuid": "^8.3.2",
         "ws": "^7.4.6"
       },
@@ -37162,13 +37909,328 @@
             "@types/node": "*"
           }
         },
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
+        "argparse": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+          "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+          "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+          "dev": true,
+          "requires": {
+            "balanced-match": "^1.0.0"
+          }
+        },
+        "camelcase": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+          "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+          "dev": true
+        },
+        "cliui": {
+          "version": "7.0.4",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+          "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+          "dev": true,
+          "requires": {
+            "string-width": "^4.2.0",
+            "strip-ansi": "^6.0.0",
+            "wrap-ansi": "^7.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "decamelize": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+          "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+          "dev": true
+        },
+        "diff": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.0.0.tgz",
+          "integrity": "sha512-/VTCrvm5Z0JGty/BWHljh+BAiw3IK+2j87NGMu8Nwc/f48WoDAC395uomO9ZD117ZOBaHmkX1oyLvkVM/aIT3w==",
+          "dev": true
+        },
+        "emoji-regex": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+          "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        },
+        "ethereum-cryptography": {
+          "version": "1.1.2",
+          "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-1.1.2.tgz",
+          "integrity": "sha512-XDSJlg4BD+hq9N2FjvotwUET9Tfxpxc3kWGE2AqUG5vcbeunnbImVk3cj6e/xT3phdW21mE8R5IugU4fspQDcQ==",
+          "dev": true,
+          "requires": {
+            "@noble/hashes": "1.1.2",
+            "@noble/secp256k1": "1.6.3",
+            "@scure/bip32": "1.1.0",
+            "@scure/bip39": "1.1.0"
+          }
+        },
+        "flat": {
+          "version": "5.0.2",
+          "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+          "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+          "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+          "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+          "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+          "dev": true,
+          "requires": {
+            "argparse": "^2.0.1"
+          }
+        },
+        "locate-path": {
+          "version": "6.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+          "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
+          "dev": true,
+          "requires": {
+            "p-locate": "^5.0.0"
+          }
+        },
+        "log-symbols": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+          "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^4.1.0",
+            "is-unicode-supported": "^0.1.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "4.1.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+              "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "7.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+              "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.0.1.tgz",
+          "integrity": "sha512-nLDxIFRyhDblz3qMuq+SoRZED4+miJ/G+tdDrjkkkRnjAsBexeGpgjLEQ0blJy7rHhR2b93rhQY4SvyWu9v03g==",
+          "dev": true,
+          "requires": {
+            "brace-expansion": "^2.0.1"
+          }
+        },
+        "mocha": {
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/mocha/-/mocha-10.1.0.tgz",
+          "integrity": "sha512-vUF7IYxEoN7XhQpFLxQAEMtE4W91acW4B6En9l97MwE9stL1A9gusXfoHZCLVHDUJ/7V5+lbCM6yMqzo5vNymg==",
+          "dev": true,
+          "requires": {
+            "ansi-colors": "4.1.1",
+            "browser-stdout": "1.3.1",
+            "chokidar": "3.5.3",
+            "debug": "4.3.4",
+            "diff": "5.0.0",
+            "escape-string-regexp": "4.0.0",
+            "find-up": "5.0.0",
+            "glob": "7.2.0",
+            "he": "1.2.0",
+            "js-yaml": "4.1.0",
+            "log-symbols": "4.1.0",
+            "minimatch": "5.0.1",
+            "ms": "2.1.3",
+            "nanoid": "3.3.3",
+            "serialize-javascript": "6.0.0",
+            "strip-json-comments": "3.1.1",
+            "supports-color": "8.1.1",
+            "workerpool": "6.2.1",
+            "yargs": "16.2.0",
+            "yargs-parser": "20.2.4",
+            "yargs-unparser": "2.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+              "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^6.0.0",
+                "path-exists": "^4.0.0"
+              }
+            }
+          }
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+          "dev": true
+        },
+        "p-limit": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+          "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+          "dev": true,
+          "requires": {
+            "yocto-queue": "^0.1.0"
+          }
+        },
+        "p-locate": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+          "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+          "dev": true,
+          "requires": {
+            "p-limit": "^3.0.2"
+          }
+        },
+        "path-exists": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+          "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
         "semver": {
           "version": "6.3.0",
           "dev": true
         },
+        "string-width": {
+          "version": "4.2.3",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+          "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^8.0.0",
+            "is-fullwidth-code-point": "^3.0.0",
+            "strip-ansi": "^6.0.1"
+          }
+        },
+        "supports-color": {
+          "version": "8.1.1",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-8.1.1.tgz",
+          "integrity": "sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        },
         "uuid": {
           "version": "8.3.2",
           "dev": true
+        },
+        "wrap-ansi": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+          "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.0.0",
+            "string-width": "^4.1.0",
+            "strip-ansi": "^6.0.0"
+          }
+        },
+        "y18n": {
+          "version": "5.0.8",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+          "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+          "dev": true
+        },
+        "yargs": {
+          "version": "16.2.0",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+          "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+          "dev": true,
+          "requires": {
+            "cliui": "^7.0.2",
+            "escalade": "^3.1.1",
+            "get-caller-file": "^2.0.5",
+            "require-directory": "^2.1.1",
+            "string-width": "^4.2.0",
+            "y18n": "^5.0.5",
+            "yargs-parser": "^20.2.2"
+          }
+        },
+        "yargs-parser": {
+          "version": "20.2.4",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.4.tgz",
+          "integrity": "sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==",
+          "dev": true
+        },
+        "yargs-unparser": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+          "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^6.0.0",
+            "decamelize": "^4.0.0",
+            "flat": "^5.0.2",
+            "is-plain-obj": "^2.1.0"
+          }
         }
       }
     },
@@ -37366,10 +38428,6 @@
       "version": "5.1.8",
       "dev": true
     },
-    "immediate": {
-      "version": "3.3.0",
-      "dev": true
-    },
     "immutable": {
       "version": "4.0.0",
       "dev": true
@@ -37384,6 +38442,12 @@
     },
     "imurmurhash": {
       "version": "0.1.4",
+      "dev": true
+    },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
     "inflight": {
@@ -37638,6 +38702,12 @@
       "version": "1.0.0",
       "dev": true
     },
+    "is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "dev": true
+    },
     "is-url": {
       "version": "1.2.4",
       "dev": true
@@ -37750,11 +38820,14 @@
       }
     },
     "keccak": {
-      "version": "3.0.1",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.2.tgz",
+      "integrity": "sha512-PyKKjkH53wDMLGrvmRGSNWgmSxZOUqbnXwKL9tmgbFYA1iAYqW21kfR7mZXV0MlESiefxQQE9X9fTa3X+2MPDQ==",
       "dev": true,
       "requires": {
         "node-addon-api": "^2.0.0",
-        "node-gyp-build": "^4.2.0"
+        "node-gyp-build": "^4.2.0",
+        "readable-stream": "^3.6.0"
       }
     },
     "keyv": {
@@ -37789,74 +38862,42 @@
         "invert-kv": "^1.0.0"
       }
     },
-    "level-codec": {
-      "version": "9.0.2",
+    "level": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/level/-/level-8.0.0.tgz",
+      "integrity": "sha512-ypf0jjAk2BWI33yzEaaotpq7fkOPALKAgDBxggO6Q9HGX2MRXn0wbP1Jn/tJv1gtL867+YOjOB49WaUF3UoJNQ==",
       "dev": true,
       "requires": {
-        "buffer": "^5.6.0"
-      }
-    },
-    "level-concat-iterator": {
-      "version": "2.0.1",
-      "dev": true
-    },
-    "level-errors": {
-      "version": "2.0.1",
-      "dev": true,
-      "requires": {
-        "errno": "~0.1.1"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "4.0.2",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0",
-        "xtend": "^4.0.2"
-      }
-    },
-    "level-mem": {
-      "version": "5.0.1",
-      "dev": true,
-      "requires": {
-        "level-packager": "^5.0.3",
-        "memdown": "^5.0.0"
-      }
-    },
-    "level-packager": {
-      "version": "5.1.1",
-      "dev": true,
-      "requires": {
-        "encoding-down": "^6.3.0",
-        "levelup": "^4.3.2"
+        "browser-level": "^1.0.1",
+        "classic-level": "^1.2.0"
       }
     },
     "level-supports": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-4.0.1.tgz",
+      "integrity": "sha512-PbXpve8rKeNcZ9C1mUicC9auIYFyGpkV9/i6g76tLgANwWhtG2v7I4xNBUlkn3lE2/dZF3Pi0ygYGtLc4RXXdA==",
+      "dev": true
+    },
+    "level-transcoder": {
       "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/level-transcoder/-/level-transcoder-1.0.1.tgz",
+      "integrity": "sha512-t7bFwFtsQeD8cl8NIoQ2iwxA0CL/9IFw7/9gAjOonH0PWTTiRfY7Hq+Ejbsxh86tXobDQ6IOiddjNYIfOBs06w==",
       "dev": true,
       "requires": {
-        "xtend": "^4.0.2"
-      }
-    },
-    "level-ws": {
-      "version": "2.0.0",
-      "dev": true,
-      "requires": {
-        "inherits": "^2.0.3",
-        "readable-stream": "^3.1.0",
-        "xtend": "^4.0.1"
-      }
-    },
-    "levelup": {
-      "version": "4.4.0",
-      "dev": true,
-      "requires": {
-        "deferred-leveldown": "~5.3.0",
-        "level-errors": "~2.0.0",
-        "level-iterator-stream": "~4.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
+        "buffer": "^6.0.3",
+        "module-error": "^1.0.1"
+      },
+      "dependencies": {
+        "buffer": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+          "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+          "dev": true,
+          "requires": {
+            "base64-js": "^1.3.1",
+            "ieee754": "^1.2.1"
+          }
+        }
       }
     },
     "levn": {
@@ -37926,10 +38967,6 @@
         }
       }
     },
-    "ltgt": {
-      "version": "2.2.1",
-      "dev": true
-    },
     "make-error": {
       "version": "1.3.6",
       "dev": true
@@ -37940,6 +38977,8 @@
     },
     "mcl-wasm": {
       "version": "0.7.9",
+      "resolved": "https://registry.npmjs.org/mcl-wasm/-/mcl-wasm-0.7.9.tgz",
+      "integrity": "sha512-iJIUcQWA88IJB/5L15GnJVnSQJmf/YaxxV6zRavv83HILHaJQb6y0iFyDMdDO0gN8X37tdxmAOrH/P8B6RB8sQ==",
       "dev": true
     },
     "md5.js": {
@@ -37955,33 +38994,15 @@
       "version": "0.3.0",
       "dev": true
     },
-    "memdown": {
-      "version": "5.1.0",
+    "memory-level": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/memory-level/-/memory-level-1.0.0.tgz",
+      "integrity": "sha512-UXzwewuWeHBz5krr7EvehKcmLFNoXxGcvuYhC41tRnkrTbJohtS7kVn9akmgirtRygg+f7Yjsfi8Uu5SGSQ4Og==",
       "dev": true,
       "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "functional-red-black-tree": "~1.0.1",
-        "immediate": "~3.2.3",
-        "inherits": "~2.0.1",
-        "ltgt": "~2.2.0",
-        "safe-buffer": "~5.2.0"
-      },
-      "dependencies": {
-        "abstract-leveldown": {
-          "version": "6.2.3",
-          "dev": true,
-          "requires": {
-            "buffer": "^5.5.0",
-            "immediate": "^3.2.3",
-            "level-concat-iterator": "~2.0.0",
-            "level-supports": "~1.0.0",
-            "xtend": "~4.0.0"
-          }
-        },
-        "immediate": {
-          "version": "3.2.3",
-          "dev": true
-        }
+        "abstract-level": "^1.0.0",
+        "functional-red-black-tree": "^1.0.1",
+        "module-error": "^1.0.1"
       }
     },
     "memorystream": {
@@ -37995,19 +39016,6 @@
     "merge2": {
       "version": "1.4.1",
       "dev": true
-    },
-    "merkle-patricia-tree": {
-      "version": "4.2.2",
-      "dev": true,
-      "requires": {
-        "@types/levelup": "^4.3.0",
-        "ethereumjs-util": "^7.1.2",
-        "level-mem": "^5.0.1",
-        "level-ws": "^2.0.0",
-        "readable-stream": "^3.6.0",
-        "rlp": "^2.2.4",
-        "semaphore-async-await": "^1.5.1"
-      }
     },
     "methods": {
       "version": "1.1.2",
@@ -38172,6 +39180,13 @@
             "locate-path": "^3.0.0"
           }
         },
+        "fsevents": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+          "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
+          "dev": true,
+          "optional": true
+        },
         "glob": {
           "version": "7.1.3",
           "dev": true,
@@ -38238,6 +39253,12 @@
       "version": "4.14.0",
       "dev": true
     },
+    "module-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/module-error/-/module-error-1.0.2.tgz",
+      "integrity": "sha512-0yuvsqSCv8LbaOKhnsQ/T5JhyFlCYLPXK3U2sgV10zoKQwzs/MyfuQUOZQ1V/6OCOJsK/TRgNVrPuPDqtdMFtA==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "dev": true
@@ -38282,6 +39303,18 @@
     },
     "nano-json-stream-parser": {
       "version": "0.1.2",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.3.tgz",
+      "integrity": "sha512-p1sjXuopFs0xg+fPASzQ28agW1oHD7xDsd9Xkf3T15H3c/cifrFHVwrh74PdoklAPi+i7MdRsE47vm2r6JoB+w==",
+      "dev": true
+    },
+    "napi-macros": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
+      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg==",
       "dev": true
     },
     "natural-compare": {
@@ -38334,7 +39367,9 @@
       "dev": true
     },
     "node-gyp-build": {
-      "version": "4.2.3",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
+      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
       "dev": true
     },
     "nofilter": {
@@ -38501,6 +39536,15 @@
       "dev": true,
       "requires": {
         "p-limit": "^1.1.0"
+      }
+    },
+    "p-map": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-4.0.0.tgz",
+      "integrity": "sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==",
+      "dev": true,
+      "requires": {
+        "aggregate-error": "^3.0.0"
       }
     },
     "p-timeout": {
@@ -38745,10 +39789,6 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       }
-    },
-    "prr": {
-      "version": "1.0.1",
-      "dev": true
     },
     "psl": {
       "version": "1.8.0",
@@ -39064,8 +40104,19 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "run-parallel-limit": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/run-parallel-limit/-/run-parallel-limit-1.1.0.tgz",
+      "integrity": "sha512-jJA7irRNM91jaKc3Hcl1npHsFLOXOoTkPCUL1JEa1R82O2miplXXRaGdjW/KM/98YQWDhJLiSs793CnXfblJUw==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
     "rustbn.js": {
       "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/rustbn.js/-/rustbn.js-0.2.0.tgz",
+      "integrity": "sha512-4VlvkRUuCJvr2J6Y0ImW7NvTCriMi7ErOAqWk1y69vAdoNIzCF3yPmgeNzx+RQTLEDFq5sHfscn1MwHxP9hNfA==",
       "dev": true
     },
     "safe-buffer": {
@@ -39145,10 +40196,6 @@
         "node-gyp-build": "^4.2.0"
       }
     },
-    "semaphore-async-await": {
-      "version": "1.5.1",
-      "dev": true
-    },
     "semver": {
       "version": "7.3.5",
       "dev": true,
@@ -39192,6 +40239,15 @@
           "version": "2.1.1",
           "dev": true
         }
+      }
+    },
+    "serialize-javascript": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
+      "integrity": "sha512-Qr3TosvguFt8ePWqsvRfrKyQXIiW+nGbYpy8XK24NQHE83caxWt+mIymTT19DGFbNWNLfEwsrkSmN64lVWB9ag==",
+      "dev": true,
+      "requires": {
+        "randombytes": "^2.1.0"
       }
     },
     "serve-static": {
@@ -39477,6 +40533,12 @@
     },
     "stealthy-require": {
       "version": "1.1.1",
+      "dev": true
+    },
+    "streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "dev": true
     },
     "strict-uri-encode": {
@@ -39783,10 +40845,6 @@
         }
       }
     },
-    "true-case-path": {
-      "version": "2.2.1",
-      "dev": true
-    },
     "ts-essentials": {
       "version": "1.0.4",
       "dev": true
@@ -39854,10 +40912,14 @@
     },
     "tweetnacl": {
       "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-1.0.3.tgz",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw==",
       "dev": true
     },
     "tweetnacl-util": {
       "version": "0.15.1",
+      "resolved": "https://registry.npmjs.org/tweetnacl-util/-/tweetnacl-util-0.15.1.tgz",
+      "integrity": "sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==",
       "dev": true
     },
     "type": {
@@ -39955,6 +41017,15 @@
     "underscore": {
       "version": "1.9.1",
       "dev": true
+    },
+    "undici": {
+      "version": "5.12.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.12.0.tgz",
+      "integrity": "sha512-zMLamCG62PGjd9HHMpo05bSLvvwWOZgGeiWlN/vlqu3+lRo3elxktVGEyLMX+IO7c2eflLjcW74AlkhEZm15mg==",
+      "dev": true,
+      "requires": {
+        "busboy": "^1.6.0"
+      }
     },
     "unfetch": {
       "version": "4.2.0",
@@ -40677,6 +41748,12 @@
       "version": "1.0.0",
       "dev": true
     },
+    "workerpool": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/workerpool/-/workerpool-6.2.1.tgz",
+      "integrity": "sha512-ILEIE97kDZvF9Wb9f6h5aXK4swSlKGUcOEGiIYb2OOu/IrDU9iwj0fD//SsA6E5ibwJxpEvhullJY4Sl4GcpAw==",
+      "dev": true
+    },
     "wrap-ansi": {
       "version": "5.1.0",
       "dev": true,
@@ -40864,6 +41941,12 @@
     },
     "yn": {
       "version": "3.1.1",
+      "dev": true
+    },
+    "yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true
     }
   }

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "ethereum-waffle": "3.4.0",
     "ethers": "5.5.1",
-    "hardhat": "^2.12.2",
+    "hardhat": "2.7.0",
     "hardhat-contract-sizer": "2.1.1",
     "hardhat-gas-reporter": "1.0.6",
     "hardhat-log-remover": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "eslint-plugin-prettier": "4.0.0",
     "ethereum-waffle": "3.4.0",
     "ethers": "5.5.1",
-    "hardhat": "2.7.0",
+    "hardhat": "^2.12.2",
     "hardhat-contract-sizer": "2.1.1",
     "hardhat-gas-reporter": "1.0.6",
     "hardhat-log-remover": "2.0.2",

--- a/test/helpers/utils.ts
+++ b/test/helpers/utils.ts
@@ -29,6 +29,7 @@ import {
   PostDataStruct,
   PostWithSigDataStruct,
 } from '../../typechain-types/LensHub';
+import { MAINNET_RPC_URL } from '../../env';
 
 export enum ProtocolState {
   Unpaused,
@@ -173,7 +174,7 @@ export async function resetFork(): Promise<void> {
     params: [
       {
         forking: {
-          jsonRpcUrl: process.env.MAINNET_RPC_URL,
+          jsonRpcUrl: MAINNET_RPC_URL,
           blockNumber: 12012081,
         },
       },


### PR DESCRIPTION
the dotenv library was imported from several files and where used without types. This change centralizes the import in a single file, adds types and default values