### PR TITLE
Update FollowNFT.sol

### DIFF
--- a/contracts/core/FollowNFT.sol
+++ b/contracts/core/FollowNFT.sol
@@ -142,7 +142,7 @@ contract FollowNFT is LensNFTBase, IFollowNFT {
         uint256 snapshotCount
     ) internal view returns (uint256) {
         unchecked {
-            uint256 lower = 0;
+            uint256 lower;
             uint256 upper = snapshotCount - 1;
 
             // First check most recent snapshot


### PR DESCRIPTION
There's no need to initialize `uint256 lower` with 0 and use some additional gas in the process, cuz the default value of 'uint' is always 0