### PR TITLE
Update LensHub.sol

### DIFF
--- a/contracts/core/LensHub.sol
+++ b/contracts/core/LensHub.sol
@@ -579,7 +579,7 @@ contract LensHub is LensNFTBase, VersionedInitializable, LensMultiState, LensHub
     {
         uint256 dataLength = vars.datas.length;
         bytes32[] memory dataHashes = new bytes32[](dataLength);
-        for (uint256 i = 0; i < dataLength; ) {
+        for (uint256 i; i < dataLength; ) {
             dataHashes[i] = keccak256(vars.datas[i]);
             unchecked {
                 ++i;


### PR DESCRIPTION
```
for (uint256 i = 0; i < dataLength; ) {
     dataHashes[i] = keccak256(vars.datas[i]);
     unchecked {
           ++i;
      }
}
```
Need to appreciate the `dev` for this gas-efficient for loop, which most of the Repos out there fail to hook upon..
Anyways, let's back to the PR, I just changed `uint256 i = 0;` to `uint256 i;` , cuz there's really no need to initialize a `uint` with 0 as the default value of all unsigned and signed integers lays back to 0 itself.

Thanks!