### PR TITLE
fix: Fix Replace triple underscores with double underscores in Follow…

### DIFF
--- a/contracts/FollowNFT.sol
+++ b/contracts/FollowNFT.sol
@@ -25,7 +25,7 @@ contract FollowNFT is HubRestricted, LensBaseERC721, ERC2981CollectionRoyalties,
     string constant FOLLOW_NFT_NAME_SUFFIX = '-Follower';
     string constant FOLLOW_NFT_SYMBOL_SUFFIX = '-Fl';
 
-    uint256[5] ___DEPRECATED_SLOTS; // Deprecated slots, previously used for delegations.
+    uint256[5] __DEPRECATED_SLOTS; // Deprecated slots, previously used for delegations.
     uint256 internal _followedProfileId;
 
     // Old uint256 `_lastFollowTokenId` slot splitted into two uint128s to include `_followerCount`.


### PR DESCRIPTION
 I noticed that triple underscores (`___`) were being used instead of the conventional double underscores (`__`) in the Solidity code.

This has been corrected to align with the standard practice of using double underscores for unused variables or slots.