### PR TITLE
Fix spelling errors

### DIFF
--- a/contracts/misc/LensHubInitializable.sol
+++ b/contracts/misc/LensHubInitializable.sol
@@ -15,7 +15,7 @@ import {VersionedInitializable} from 'contracts/base/upgradeability/VersionedIni
  * @notice Extension of LensHub contract that includes initialization for fresh deployments.
  *
  * @custom:upgradeable Transparent upgradeable proxy.
- * See `../LensHub.sol` for the version without initalizer.
+ * See `../LensHub.sol` for the version without initializer.
  */
 contract LensHubInitializable is LensHub, VersionedInitializable, ILensHubInitializable {
     // Constant for upgradeability purposes, see VersionedInitializable.

--- a/test/LensBaseERC721Test.t.sol
+++ b/test/LensBaseERC721Test.t.sol
@@ -356,7 +356,7 @@ abstract contract LensBaseERC721Test is ERC721Test {
     // Minting to address(0) is tested through the MockNFT instead of using `_LensERC721()._mintERC721(address(0))`
     // because on inherited test contracts like FollowNFTTest, ProfileNFTTest, etc, we cannot reach the required
     // preconditions to test it (e.g. a profile being owned by address(0), to then perform a follow or collect).
-    // This test can be overriden by any future contract that can meet the needed preconditions.
+    // This test can be overridden by any future contract that can meet the needed preconditions.
     function testCannot_MintToZero(uint256 tokenId) public virtual {
         MockNFT nft = new MockNFT();
 

--- a/test/LensHubTest.t.sol
+++ b/test/LensHubTest.t.sol
@@ -36,7 +36,7 @@ contract LensHubTest is BaseTest {
         hub.createProfile(createProfileParams);
     }
 
-    function testCannot_CreateProfile_IfRecepientIsZero() public {
+    function testCannot_CreateProfile_IfRecipientIsZero() public {
         Types.CreateProfileParams memory createProfileParams = _getDefaultCreateProfileParams();
 
         createProfileParams.to = address(0);

--- a/test/ReferralSystem.t.sol
+++ b/test/ReferralSystem.t.sol
@@ -195,7 +195,7 @@ abstract contract ReferralSystemTest is BaseTest {
                         _executeOperation(target, quoteOrCommentAsReferralPub);
                     }
 
-                    // One special case is a post as referal for reference node
+                    // One special case is a post as referral for reference node
                     console.log('Special case: Target as a quote/comment node and pass post as referral');
                     TestPublication memory referralPub = treeV2.post;
                     // vm.expectCall /* */();

--- a/test/misc/ProxyAdminTest.t.sol
+++ b/test/misc/ProxyAdminTest.t.sol
@@ -78,7 +78,7 @@ contract ProxyAdminTest is BaseTest {
 
     // Scenarios
 
-    function testContructor() public notFork {
+    function testConstructor() public notFork {
         assertEq(address(proxyAdminContract.LENS_HUB_PROXY()), address(hub), 'Hub address is not set correctly');
         assertEq(
             proxyAdminContract.previousImplementation(),


### PR DESCRIPTION
- Corrected "initalizer" to "initializer" in `LensHubInitializable.sol`.
- Fixed "overriden" to "overridden" in `LensBaseERC721Test.t.sol`.
- Corrected "Recepient" to "Recipient" in `LensHubTest.t.sol`.
- Fixed "referal" to "referral" in `ReferralSystem.t.sol`.
- Corrected "Contructor" to "Constructor" in `ProxyAdminTest.t.sol`.
