### PR TITLE
fix: Fix typos in environment variable names in envGen.js

### DIFF
--- a/script/helpers/envGen.js
+++ b/script/helpers/envGen.js
@@ -52,7 +52,7 @@ str.write(`\n# Profile creation proxy\n`);
 str.write(`PROFILE_CREATION_PROXY=${addressOrZero('ProfileCreationProxy')}\n`);
 
 str.write(`\n# Permissionless creator\n`);
-str.write(`PERMISSONLESS_CREATOR=${addresses['PermissionlessCreator']}\n`);
+str.write(`PERMISSIONLESS_CREATOR=${addresses['PermissionlessCreator']}\n`);
 
 str.write(`\n# Credits faucet\n`);
 str.write(`CREDITS_FAUCET=${addressOrZero('CreditsFaucet')}\n`);
@@ -120,7 +120,7 @@ str.write(
   )}\n`
 );
 str.write(
-  `LEGACY_DEGREE_OF_SEPERATION_REFERENCE_MODULE=${findModule(
+  `LEGACY_DEGREE_OF_SEPARATION_REFERENCE_MODULE=${findModule(
     'reference',
     'DegreesOfSeparationReferenceModule',
     'v1'
@@ -157,7 +157,7 @@ str.write(`REVERT_FOLLOW_MODULE=${findModule('follow', 'RevertFollowModule', 'v2
 // V2 REFERENCE MODULES
 str.write(`\n## v2 reference modules\n`);
 str.write(
-  `DEGREE_OF_SEPERATION_REFERENCE_MODULE=${findModule(
+  `DEGREE_OF_SEPARATION_REFERENCE_MODULE=${findModule(
     'reference',
     'DegreesOfSeparationReferenceModule',
     'v2'


### PR DESCRIPTION
Corrected typos in environment variable names in envGen.js

- Fixed "PERMISSONLESS_CREATOR" → "PERMISSIONLESS_CREATOR" (missing "i").

- Fixed "DEGREE_OF_SEPERATION_REFERENCE_MODULE" → "DEGREE_OF_SEPARATION_REFERENCE_MODULE" (incorrect spelling of "separation").

- Fixed "LEGACY_DEGREE_OF_SEPERATION_REFERENCE_MODULE" → "LEGACY_DEGREE_OF_SEPARATION_REFERENCE_MODULE" (same typo).